### PR TITLE
Fix names of dijet variables to match naming scheme.

### DIFF
--- a/examples/002_jet_lepton_distances/plot_jet_lepon_pt_rel_delta_r.sh
+++ b/examples/002_jet_lepton_distances/plot_jet_lepon_pt_rel_delta_r.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#
+# example commands for plotting jet/lepton distances
+#
+
+# law args
+args=(
+    --version test_jet_lepton_distances
+    --categories 1e,1m
+    --processes
+        tt,w_lnu,dy_lep,st,qcd,vv,zprime_tt_m500_w50,zprime_tt_m1000_w100,zprime_tt_m3000_w300
+
+    #--calibrator skip_jecunc_wo_cleaner
+    --calibrator skip_jecunc
+    --producers weights,jet_lepton_features 
+    --workers 8
+    #--workflow htcondor
+    #--local-scheduler False
+    $@
+)
+
+# 2D distributions
+law run cf.PlotVariables2D \
+    --variables jet_lep_delta_r-jet_lep_pt_rel,jet_lep_delta_r_zoom-jet_lep_pt_rel_zoom \
+    --shape-norm True \
+    "${args[@]}"
+
+# 1D distributions
+law run cf.PlotVariables1D \
+    --variables jet_lep_delta_r,jet_lep_pt_rel,jet_lep_delta_r_zoom,jet_lep_pt_rel_zoom \
+    --skip-ratio \
+    --hide-errors \
+    --process-settings \
+        "tt,unstack:w_lnu,unstack:dy_lep,unstack:st,unstack:qcd,unstack:vv,unstack:zprime_tt_m500_w50:color1=#000000:zprime_tt_m1000_w100:color1=#cccccc:zprime_tt_m3000_w300:color1=#666666" \
+    "${args[@]}"

--- a/mtt/calibration/default.py
+++ b/mtt/calibration/default.py
@@ -41,3 +41,16 @@ def skip_jecunc(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     events = self[jet_energy](events, **kwargs)
 
     return events
+
+@calibrator(
+    uses={mc_weight, deterministic_seeds, jet_energy},
+    produces={mc_weight, deterministic_seeds, jet_energy},
+)
+def skip_jecunc_wo_cleaner(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
+    """ only uses jec_nominal for test purposes """
+    if self.dataset_inst.is_mc:
+        events = self[mc_weight](events, **kwargs)
+    events = self[deterministic_seeds](events, **kwargs)
+    events = self[jet_energy](events, **kwargs)
+
+    return events

--- a/mtt/calibration/default.py
+++ b/mtt/calibration/default.py
@@ -42,6 +42,7 @@ def skip_jecunc(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
 
     return events
 
+
 @calibrator(
     uses={mc_weight, deterministic_seeds, jet_energy},
     produces={mc_weight, deterministic_seeds, jet_energy},

--- a/mtt/config/variables.py
+++ b/mtt/config/variables.py
@@ -137,6 +137,32 @@ def add_variables(config: od.Config) -> None:
         x_title=r"$\Delta R(j_{1},j_{2})$",
     )
 
+    # jet lepton features
+    config.add_variable(
+        name=f"jet_lep_pt_rel",
+        binning=(40, 0, 400),
+        unit="GeV",
+        x_title=r"$p_{T}^{rel}$",
+    )
+    config.add_variable(
+        name=f"jet_lep_delta_r",
+        binning=(40, 0, 5),
+        x_title=r"$\Delta R(jet, lep)$",
+    )
+    config.add_variable(
+        name=f"jet_lep_pt_rel_zoom",
+        expression=f"jet_lep_pt_rel",
+        binning=(10, 0, 50),
+        unit="GeV",
+        x_title=r"$p_{T}^{rel}$",
+    )
+    config.add_variable(
+        name=f"jet_lep_delta_r_zoom",
+        expression=f"jet_lep_delta_r",
+        binning=(15, 0, 1.4),
+        x_title=r"$\Delta R(jet, lep)$",
+    )
+
     # ttbar features
     config.add_variable(
         name=f"chi2",
@@ -148,6 +174,12 @@ def add_variables(config: od.Config) -> None:
         name=f"chi2_lt30",
         expression=f"TTbar.chi2",
         binning=(15, 0, 30),
+        x_title=rf"$\chi^2$",
+    )
+    config.add_variable(
+        name=f"chi2_lt100",
+        expression=f"TTbar.chi2",
+        binning=(20, 0, 100),
         x_title=rf"$\chi^2$",
     )
     config.add_variable(

--- a/mtt/config/variables.py
+++ b/mtt/config/variables.py
@@ -126,13 +126,13 @@ def add_variables(config: od.Config) -> None:
 
     # jj features
     config.add_variable(
-        name="m_jj",
+        name="dijet_mass",
         binning=(40, 0., 400.),
         unit="GeV",
         x_title=r"$m_{jj}$",
     )
     config.add_variable(
-        name="deltaR_jj",
+        name="dijet_delta_r",
         binning=(40, 0, 5),
         x_title=r"$\Delta R(j_{1},j_{2})$",
     )

--- a/mtt/config/variables.py
+++ b/mtt/config/variables.py
@@ -153,13 +153,15 @@ def add_variables(config: od.Config) -> None:
     config.add_variable(
         name=f"ttbar_mass",
         expression=f"TTbar.mass",
-        binning=(300, 300, 3300),
+        binning=(30, 300, 3300),
+        unit="GeV",
         x_title=r"$m({t}\overline{t})$",
     )
     config.add_variable(
         name=f"ttbar_mass_wide",
         expression=f"TTbar.mass",
         binning=(30, 0, 6000),
+        unit="GeV",
         x_title=r"$m({t}\overline{t})$",
     )
     config.add_variable(

--- a/mtt/config/variables.py
+++ b/mtt/config/variables.py
@@ -147,27 +147,27 @@ def add_variables(config: od.Config) -> None:
 
     # jet lepton features
     config.add_variable(
-        name=f"jet_lep_pt_rel",
+        name="jet_lep_pt_rel",
         binning=(40, 0, 400),
         unit="GeV",
         x_title=r"$p_{T}^{rel}$",
     )
     config.add_variable(
-        name=f"jet_lep_delta_r",
+        name="jet_lep_delta_r",
         binning=(40, 0, 5),
         x_title=r"$\Delta R(jet, lep)$",
     )
     config.add_variable(
-        name=f"jet_lep_pt_rel_zoom",
-        expression=f"jet_lep_pt_rel",
+        name="jet_lep_pt_rel_zoom",
+        expression="jet_lep_pt_rel",
         binning=(10, 0, 50),
         unit="GeV",
         x_title=r"$p_{T}^{rel}$",
     )
     config.add_variable(
-        name=f"jet_lep_delta_r_zoom",
-        expression=f"jet_lep_delta_r",
-        binning=(15, 0, 1.4),
+        name="jet_lep_delta_r_zoom",
+        expression="jet_lep_delta_r",
+        binning=(15, 0, 1.5),
         x_title=r"$\Delta R(jet, lep)$",
     )
 

--- a/mtt/production/default.py
+++ b/mtt/production/default.py
@@ -25,11 +25,11 @@ ak = maybe_import("awkward")
 )
 def default(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
-    # features
-    events = self[features](events, **kwargs)
-
     # ttbar reconstruction
     events = self[ttbar](events, **kwargs)
+
+    # features
+    events = self[features](events, **kwargs)
 
     # weights
     events = self[weights](events, **kwargs)

--- a/mtt/production/features.py
+++ b/mtt/production/features.py
@@ -36,7 +36,7 @@ def jet_energy_shifts_init(self: Producer) -> None:
 
 @producer(
     uses={"Jet.pt", "Jet.eta", "Jet.phi", "Jet.mass"},
-    produces={"m_jj", "deltaR_jj"},
+    produces={"dijet_mass", "dijet_delta_r"},
 )
 def jj_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     events = ak.Array(events, behavior=coffea.nanoevents.methods.nanoaod.behavior)
@@ -46,12 +46,12 @@ def jj_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     jets = ak.pad_none(events.Jet, 2)
 
     # calculate and save invariant mass
-    m_jj = (jets[:, 0] + jets[:, 1]).mass
-    events = set_ak_column(events, "m_jj", m_jj)
+    dijet_mass = (jets[:, 0] + jets[:, 1]).mass
+    events = set_ak_column(events, "dijet_mass", dijet_mass)
 
     # calculate and save delta-R
-    deltaR_jj = jets[:, 0].delta_r(jets[:, 1])
-    events = set_ak_column(events, "deltaR_jj", deltaR_jj)
+    dijet_delta_r = jets[:, 0].delta_r(jets[:, 1])
+    events = set_ak_column(events, "dijet_delta_r", dijet_delta_r)
 
     return events
 

--- a/mtt/production/features.py
+++ b/mtt/production/features.py
@@ -6,7 +6,7 @@ Column production methods related to higher-level features.
 
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import
-from columnflow.columnar_util import set_ak_column
+from columnflow.columnar_util import set_ak_column, EMPTY_FLOAT
 from columnflow.production.util import attach_coffea_behavior
 from mtt.production.ttbar_reco import choose_lepton
 from mtt.selection.util import masked_sorted_indices
@@ -58,7 +58,6 @@ def jj_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     return events
 
 
-
 @producer(
     uses={
         attach_coffea_behavior,
@@ -66,14 +65,14 @@ def jj_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         "Muon.pt", "Muon.eta", "Muon.phi", "Muon.mass", "nMuon",
         "Jet.pt", "Jet.eta", "Jet.phi", "Jet.mass", "nJet",
         "Jet.muonIdx1", "Jet.muonIdx2", "Jet.electronIdx1", "Jet.electronIdx2",
-        choose_lepton
+        choose_lepton,
     },
     produces={
         attach_coffea_behavior,
         "jet_lep_pt_rel", "jet_lep_delta_r",
     },
 )
-def jet_lepton_features(self:Producer, events: ak.Array, **kwargs) -> ak.Array:
+def jet_lepton_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
     Produces jet lepton pTrel and deltaR.
     """
@@ -107,8 +106,8 @@ def jet_lepton_features(self:Producer, events: ak.Array, **kwargs) -> ak.Array:
     jet_lep_delta_r = lepton_closest_jet.delta_r(lepton)
 
     # save as new columns
-    events = set_ak_column(events, "jet_lep_pt_rel", jet_lep_pt_rel)
-    events = set_ak_column(events, "jet_lep_delta_r", jet_lep_delta_r)
+    events = set_ak_column(events, "jet_lep_pt_rel",  ak.fill_none(jet_lep_pt_rel, EMPTY_FLOAT))
+    events = set_ak_column(events, "jet_lep_delta_r", ak.fill_none(jet_lep_delta_r, EMPTY_FLOAT))
 
     return events
 

--- a/mtt/production/features.py
+++ b/mtt/production/features.py
@@ -94,7 +94,7 @@ def jet_lepton_features(self:Producer, events: ak.Array, **kwargs) -> ak.Array:
     # attach lorentz vector behavior to lepton
     lepton = ak.with_name(lepton, "PtEtaPhiMLorentzVector")
 
-    # calculate deltaR
+    # calculate deltaR between lepton and every jet
     lepton_jet_deltar = ak.firsts(jets.metric_table(lepton), axis=-1)
 
     # define closest lepton to jet


### PR DESCRIPTION
This PR changed the names of m_jj to dijet_mass and deltaR_jj to dijet_delta_r to match naming scheme of the other variables.
It also added units to the ttbar_mass(_wide) variables to show up in plots and fixed in the number of bins for ttbar_mass.