### PR TITLE
Update Columnflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ data
 .law
 .setups
 workflow_scripts/*
+luigi-server*

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ data
 .data
 .law
 .setups
+workflow_scripts/*

--- a/law.cfg
+++ b/law.cfg
@@ -20,7 +20,7 @@ gfal2: WARNING
 
 default_analysis: mtt.config.run2.analysis_mtt.analysis_mtt
 default_config: run2_mtt_2017_nano_v9_limited
-default_dataset: zprime_tt_m400_w40_madgraph
+default_dataset: tt_sl_powheg
 
 production_modules: columnflow.production.{categories,normalization,mc_weight,pileup,processes,seeds}, mtt.production.{default,features,lepton,neutrino,ttbar_reco,ttbar_gen,ml_inputs}
 calibration_modules: columnflow.calibration.jets, mtt.calibration.{default,test}
@@ -115,7 +115,9 @@ cache_max_size: 50GB
 [wlcg_fs_desy]
 
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
-gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
+gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
+webdav_base: davs://dcache-cms-webdav.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
+# base: &::xrootd_base
 base: &::gsiftp_base
 
 

--- a/law.cfg
+++ b/law.cfg
@@ -25,6 +25,7 @@ default_dataset: tt_sl_powheg
 production_modules: columnflow.production.{categories,normalization,mc_weight,pileup,processes,seeds}, mtt.production.{default,features,lepton,neutrino,ttbar_reco,ttbar_gen,ml_inputs}
 calibration_modules: columnflow.calibration.jets, mtt.calibration.{default,test}
 selection_modules: mtt.selection.categories, mtt.selection.default, mtt.selection.default_without_2d_selection, mtt.production.categories
+reduction_modules: columnflow.reduction.default, mtt.reduction.default
 categorization_modules: columnflow.categorization, mtt.production.categories
 weight_production_modules: columnflow.weight.{empty,all_weights}
 ml_modules: mtt.ml.simple, mtt.ml.simple_pimped
@@ -63,31 +64,31 @@ lfn_sources: local_desy_dcache, wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlc
 # output locations per task family
 # for local targets : "local[, STORE_PATH]"
 # for remote targets: "wlcg[, WLCG_FS_NAME]"
-cf.BundleRepo: local
-cf.BundleSoftware: local
-cf.BundleBashSandbox: local
-cf.BundleCMSSWSandbox: local
-cf.BundleExternalFiles: local
+task_cf.BundleRepo: local
+task_cf.BundleSoftware: local
+task_cf.BundleBashSandbox: local
+task_cf.BundleCMSSWSandbox: local
+task_cf.BundleExternalFiles: local
 # NOTE: at some point, switch output location of more tasks to a common space (wlcg or local)
-cf.GetDatasetLFNs: local
-cf.CalibrateEvents: wlcg
-cf.SelectEvents: wlcg
-cf.CreateCutflowHistograms: wlcg
-cf.PlotCutflow: local
-cf.PlotCutflowVariables: wlcg
-cf.ReduceEvents: wlcg
-cf.MergeReducedEvents: wlcg
-cf.ProduceColumns: wlcg
-cf.PrepareMLEvents: wlcg
-cf.MergeMLEvents: wlcg
-cf.MLTraining: wlcg
-cf.MLEvaluation: wlcg
-cf.CreateHistograms: local
-cf.MergeHistograms: local
-cf.MergeShiftedHistograms: local
-cf.PlotVariables: local
-cf.PlotShiftedVariables: local
-cf.CreateDatacards: local
+task_cf.GetDatasetLFNs: local
+task_cf.CalibrateEvents: wlcg
+task_cf.SelectEvents: wlcg
+task_cf.CreateCutflowHistograms: wlcg
+task_cf.PlotCutflow: local
+task_cf.PlotCutflowVariables: wlcg
+task_cf.ReduceEvents: wlcg
+task_cf.MergeReducedEvents: wlcg
+task_cf.ProduceColumns: wlcg
+task_cf.PrepareMLEvents: wlcg
+task_cf.MergeMLEvents: wlcg
+task_cf.MLTraining: wlcg
+task_cf.MLEvaluation: wlcg
+task_cf.CreateHistograms: local
+task_cf.MergeHistograms: local
+task_cf.MergeShiftedHistograms: local
+task_cf.PlotVariables: local
+task_cf.PlotShiftedVariables: local
+task_cf.CreateDatacards: local
 
 
 [job]

--- a/law.cfg
+++ b/law.cfg
@@ -117,9 +117,9 @@ cache_max_size: 50GB
 
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
 gsiftp_base: gsiftp://dcache-cms-gridftp.desy.de/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
-webdav_base: davs://dcache-cms-webdav.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
-# base: &::xrootd_base
-base: &::gsiftp_base
+webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/$CF_CERN_USER/$CF_STORE_NAME
+base: &::webdav_base
+# base: &::gsiftp_base
 
 
 [wlcg_fs_cernbox]

--- a/mtt/calibration/jets.py
+++ b/mtt/calibration/jets.py
@@ -19,6 +19,7 @@ np = maybe_import("numpy")
 
 # custom jec calibrator that only runs nominal correction
 jec_nominal = jec.derive("jec_nominal", cls_dict={"uncertainty_sources": []})
+jer_nominal = jer.derive("jer_nominal", cls_dict={"jec_uncertainty_sources": []})
 
 
 @calibrator
@@ -31,7 +32,7 @@ def jet_energy(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     if self.dataset_inst.is_mc:
         # TODO: for testing purposes, only run jec_nominal for now
         events = self[jec_nominal](events, **kwargs)
-        events = self[jer](events, **kwargs)
+        events = self[jer_nominal](events, **kwargs)
     else:
         events = self[jec_nominal](events, **kwargs)
 
@@ -43,8 +44,8 @@ def jet_energy_init(self: Calibrator) -> None:
     # add standard jec and jer for mc, and only jec nominal for dta
     if getattr(self, "dataset_inst", None) and self.dataset_inst.is_mc:
         # TODO: for testing purposes, only run jec_nominal for now
-        self.uses |= {jec_nominal, jer}
-        self.produces |= {jec_nominal, jer}
+        self.uses |= {jec_nominal, jer_nominal}
+        self.produces |= {jec_nominal, jer_nominal}
     else:
         self.uses |= {jec_nominal}
         self.produces |= {jec_nominal}

--- a/mtt/config/categories.py
+++ b/mtt/config/categories.py
@@ -37,7 +37,7 @@ parent category.
 import order as od
 
 from columnflow.ml import MLModel
-from columnflow.config_util import create_category_combinations
+from columnflow.config_util import create_category_combinations, CategoryGroup
 
 from mtt.ml.categories import register_ml_selectors
 
@@ -107,14 +107,8 @@ def add_categories_selection(config: od.Config) -> None:
     # -- combined categories
 
     category_groups = {
-        "lepton": [
-            config.get_category(name)
-            for name in ["1e", "1m"]
-        ],
-        "n_top_tags": [
-            config.get_category(name)
-            for name in ["0t", "1t"]
-        ],
+        "lepton": CategoryGroup(["1e", "1m"], is_complete=True, has_overlap=False),
+        "n_top_tags": CategoryGroup(["0t", "1t"], is_complete=False, has_overlap=False),
     }
 
     create_category_combinations(config, category_groups, name_fn, kwargs_fn)
@@ -172,22 +166,14 @@ def add_categories_production(config: od.Config) -> None:
     # -- combined categories
 
     category_groups = {
-        "lepton": [
-            config.get_category(name)
-            for name in ["1e", "1m"]
-        ],
-        "n_top_tags": [
-            config.get_category(name)
-            for name in ["0t", "1t"]
-        ],
-        "chi2": [
-            config.get_category(name)
-            for name in ["chi2pass", "chi2fail"]
-        ],
-        "cos_theta_star": [
-            config.get_category(name)
-            for name in ["acts_0_5", "acts_5_7", "acts_7_9", "acts_9_1"]
-        ],
+        "lepton": CategoryGroup(["1e", "1m"], is_complete=True, has_overlap=False),
+        "n_top_tags": CategoryGroup(["0t", "1t"], is_complete=False, has_overlap=False),
+        "chi2": CategoryGroup(["chi2pass", "chi2fail"], is_complete=True, has_overlap=False),
+        "cos_theta_star": CategoryGroup(
+            ["acts_0_5", "acts_5_7", "acts_7_9", "acts_9_1"],
+            is_complete=True,
+            has_overlap=False,
+        ),
     }
 
     create_category_combinations(config, category_groups, name_fn, kwargs_fn)
@@ -214,28 +200,6 @@ def add_categories_ml(config: od.Config, ml_model_inst: MLModel) -> None:
             label=f"dnn_{proc}",
         )
         dnn_categories.append(cat)
-
-    # -- combined categories
-
-    category_groups = {
-        "lepton": [
-            config.get_category(name)
-            for name in ["1e", "1m"]
-        ],
-        "n_top_tags": [
-            config.get_category(name)
-            for name in ["0t", "1t"]
-        ],
-        "chi2": [
-            config.get_category(name)
-            for name in ["chi2pass", "chi2fail"]
-        ],
-        "cos_theta_star": [
-            config.get_category(name)
-            for name in ["acts_0_5", "acts_5_7", "acts_7_9", "acts_9_1"]
-        ],
-        "dnn": dnn_categories,
-    }
 
     # fixed numbering scheme for ML categories
     def kwargs_fn_dnn(categories: dict[str, od.Category]):
@@ -279,6 +243,20 @@ def add_categories_ml(config: od.Config, ml_model_inst: MLModel) -> None:
                 cat.label for cat in categories.values()
             ),
         }
+    
+    # -- combined categories
+
+    category_groups = {
+        "lepton": CategoryGroup(["1e", "1m"], is_complete=True, has_overlap=False),
+        "n_top_tags": CategoryGroup(["0t", "1t"], is_complete=False, has_overlap=False),
+        "chi2": CategoryGroup(["chi2pass", "chi2fail"], is_complete=True, has_overlap=False),
+        "cos_theta_star": CategoryGroup(
+            ["acts_0_5", "acts_5_7", "acts_7_9", "acts_9_1"],
+            is_complete=True,
+            has_overlap=False,
+        ),
+        "dnn": CategoryGroup(dnn_categories, is_complete=True, has_overlap=False),
+    }
 
     create_category_combinations(
         config,

--- a/mtt/config/run2/analysis_mtt.py
+++ b/mtt/config/run2/analysis_mtt.py
@@ -68,5 +68,5 @@ config_2017_limited = add_config(
     campaign_run2_2017_nano_v9.copy(),
     config_name="run2_mtt_2017_nano_v9_limited",
     config_id=2_17_2,  # 2: Run2 17: year 2: limited stat
-    limit_dataset_files=1,
+    limit_dataset_files=2,
 )

--- a/mtt/config/run2/config_mtt.py
+++ b/mtt/config/run2/config_mtt.py
@@ -624,7 +624,9 @@ def add_config(
     cfg.x.default_calibrator = "skip_jecunc"
     cfg.x.default_selector = "default"
     cfg.x.default_producer = "default"
+    cfg.x.default_reducer = "cf_default"
     cfg.x.default_weight_producer = "all_weights"
+    cfg.x.default_hist_producer = "cf_default"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = "simple"
     cfg.x.default_categories = ["incl", "1e", "1m"]

--- a/mtt/config/run3/analysis_mtt.py
+++ b/mtt/config/run3/analysis_mtt.py
@@ -97,7 +97,7 @@ config_2022_preEE_limited = add_config(
     campaign_run3_2022_preEE_nano_v12.copy(),
     config_name="run3_mtt_2022_preEE_nano_v12_limited",
     config_id=3_22_21,  # 3: Run3 22: year 2: limited stat 1: pre EE
-    limit_dataset_files=1,
+    limit_dataset_files=2,
 )
 
 config_2022_postEE_limited = add_config(
@@ -105,7 +105,7 @@ config_2022_postEE_limited = add_config(
     campaign_run3_2022_postEE_nano_v12.copy(),
     config_name="run3_mtt_2022_postEE_nano_v12_limited",
     config_id=3_22_22,  # 3: Run3 22: year 2: limited stat 2: post EE
-    limit_dataset_files=1,
+    limit_dataset_files=2,
 )
 
 # config with medium limited number of files

--- a/mtt/config/run3/config_mtt.py
+++ b/mtt/config/run3/config_mtt.py
@@ -132,8 +132,8 @@ def add_config(
     # errors taken over from top sf analysis, might work in this analysis
     dataset_names = [
         # DY 2022 v12 preEE datasets
-        # "dy_m4to50_ht40to70_madgraph",  # FIXME AssertionError in preEE (full stat.)
-        # "dy_m4to50_ht70to100_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        "dy_m4to50_ht40to70_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        "dy_m4to50_ht70to100_madgraph",  # FIXME AssertionError in preEE (full stat.)
         "dy_m4to50_ht100to400_madgraph",
         "dy_m4to50_ht400to800_madgraph",
         "dy_m4to50_ht800to1500_madgraph",
@@ -148,7 +148,7 @@ def add_config(
         "w_lnu_mlnu0to120_ht100to400_madgraph",
         "w_lnu_mlnu0to120_ht400to800_madgraph",
         "w_lnu_mlnu0to120_ht800to1500_madgraph",
-        # "w_lnu_mlnu0to120_ht1500to2500_madgraph",
+        "w_lnu_mlnu0to120_ht1500to2500_madgraph",
         "w_lnu_mlnu0to120_ht2500toinf_madgraph",
         # Diboson
         "ww_pythia",
@@ -168,11 +168,11 @@ def add_config(
         "st_twchannel_t_fh_powheg",
         "st_twchannel_tbar_fh_powheg",
         # QCD 2022 v12 preEE datasets
-        # "qcd_ht70to100_madgraph",  # FIXME AssertionError in preEE (full stat.)
-        # "qcd_ht100to200_madgraph",  # FIXME no xs for 13.6 in https://xsdb-temp.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS%3DQCD-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8  # noqa
-        # "qcd_ht200to400_madgraph",  # FIXME AssertionError in preEE (full stat.)
-        # "qcd_ht400to600_madgraph",  # FIXME AssertionError in preEE (full stat.)
-        # "qcd_ht600to800_madgraph",
+        "qcd_ht70to100_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        "qcd_ht100to200_madgraph",  # FIXME no xs for 13.6 in https://xsdb-temp.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS%3DQCD-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8  # noqa
+        "qcd_ht200to400_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        "qcd_ht400to600_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        "qcd_ht600to800_madgraph",
         "qcd_ht800to1000_madgraph",
         "qcd_ht1000to1200_madgraph",
         "qcd_ht1200to1500_madgraph",
@@ -644,7 +644,7 @@ def add_config(
     # default calibrator, selector, producer, ml model and inference model
     cfg.x.default_calibrator = "skip_jecunc"
     cfg.x.default_selector = "default"
-    cfg.x.default_reducer = "cf_default"
+    cfg.x.default_reducer = "default"
     cfg.x.default_producer = "default"
     cfg.x.default_weight_producer = "all_weights"
     cfg.x.default_hist_producer = "cf_default"
@@ -1364,7 +1364,7 @@ def add_config(
             "Muon.pfRelIso04_all",
             # electrons
             "Electron.pt", "Electron.eta", "Electron.phi", "Electron.mass",
-            "VetoElectron.pt", "VetoElectron.eta", "VetoElectron.phi", "VetoElecton.mass",
+            "VetoElectron.pt", "VetoElectron.eta", "VetoElectron.phi", "VetoElectron.mass",
             "Electron.deltaEtaSC",
             "Electron.pfRelIso03_all",
 

--- a/mtt/config/run3/config_mtt.py
+++ b/mtt/config/run3/config_mtt.py
@@ -644,8 +644,10 @@ def add_config(
     # default calibrator, selector, producer, ml model and inference model
     cfg.x.default_calibrator = "skip_jecunc"
     cfg.x.default_selector = "default"
+    cfg.x.default_reducer = "cf_default"
     cfg.x.default_producer = "default"
     cfg.x.default_weight_producer = "all_weights"
+    cfg.x.default_hist_producer = "cf_default"
     cfg.x.default_ml_model = None
     cfg.x.default_inference_model = "simple"
     cfg.x.default_categories = ["incl", "1e", "1m"]

--- a/mtt/production/gen_v.py
+++ b/mtt/production/gen_v.py
@@ -7,8 +7,9 @@ Producers for L1 prefiring weights.
 from __future__ import annotations
 
 from columnflow.production import Producer, producer
-from columnflow.util import maybe_import, InsertableDict, DotDict
+from columnflow.util import maybe_import, DotDict
 from columnflow.columnar_util import set_ak_column
+from law.util import InsertableDict
 
 
 np = maybe_import("numpy")

--- a/mtt/production/l1_prefiring.py
+++ b/mtt/production/l1_prefiring.py
@@ -13,8 +13,9 @@ from functools import reduce
 
 from columnflow.production import Producer, producer
 from columnflow.production.util import attach_coffea_behavior
-from columnflow.util import maybe_import, InsertableDict, DotDict
+from columnflow.util import maybe_import, DotDict
 from columnflow.columnar_util import set_ak_column, flat_np_view, layout_ak_array
+from law.util import InsertableDict
 
 
 np = maybe_import("numpy")

--- a/mtt/production/toptag.py
+++ b/mtt/production/toptag.py
@@ -7,8 +7,9 @@ Column producers related to top-tagged jets.
 from __future__ import annotations
 
 from columnflow.production import Producer, producer
-from columnflow.util import maybe_import, InsertableDict
+from columnflow.util import maybe_import
 from columnflow.columnar_util import set_ak_column, flat_np_view, layout_ak_array
+from law.util import InsertableDict
 
 
 ak = maybe_import("awkward")

--- a/mtt/production/ttbar_reco.py
+++ b/mtt/production/ttbar_reco.py
@@ -5,6 +5,7 @@ Column production methods related to ttbar mass reconstruction.
 """
 import itertools
 import math
+import law
 
 from law.util import human_duration
 
@@ -47,6 +48,7 @@ maybe_import("coffea.nanoevents.methods.nanoaod")
 def ttbar(
     self: Producer,
     events: ak.Array,
+    task: law.Task,
     # algorithm tweaks
     merge_mode="eager",
     # profiling/reporting options
@@ -115,7 +117,7 @@ def ttbar(
 
     # validate merging mode
     assert merge_mode in ("eager", "lazy"), f"invalid merge_mode '{merge_mode}'"
-    self.task.publish_message(f"merge mode is '{merge_mode}'")
+    task.publish_message(f"merge mode is '{merge_mode}'")
 
     # load coffea behaviors for simplified arithmetic with vectors
     events = ak.Array(events, behavior=coffea.nanoevents.methods.nanoaod.behavior)
@@ -243,7 +245,7 @@ def ttbar(
             task_name=name,
             # report on task completion
             msg_func=(
-                self.task.publish_message
+                task.publish_message  # FIXME broken after cf_taf
                 if verbose_level >= min_verbose_level
                 else None
             ),
@@ -555,7 +557,7 @@ def ttbar(
         result = None
         size = len(arrays[0])
         n_chunks = max(1, int(math.ceil(size / max_chunk_size)))
-        self.task.publish_message(
+        task.publish_message(
             f"processing {size} events in {n_chunks} sub-chunks",
         )
         for i_chk, arrays_chk in enumerate(

--- a/mtt/production/weights.py
+++ b/mtt/production/weights.py
@@ -28,15 +28,15 @@ def weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
     if self.dataset_inst.is_mc:
         # compute electron weights
-        electron_mask = (events.Electron.pt >= 35)
+        electron_mask = (events.Electron["pt"] >= 35)
         events = self[electron_weights](events, electron_mask=electron_mask, **kwargs)
 
         # compute muon weights
-        muon_mask = (events.Muon.pt >= 30) & (abs(events.Muon.eta) < 2.4)
+        muon_mask = (events.Muon["pt"] >= 30) & (abs(events.Muon["eta"]) < 2.4)
         events = self[muon_weights](events, muon_mask=muon_mask, **kwargs)
 
         # compute btag weights
-        jet_mask = (events.Jet.pt >= 100) & (abs(events.Jet.eta) < 2.5)
+        jet_mask = (events.Jet["pt"] >= 100) & (abs(events.Jet["eta"]) < 2.5)
         events = self[btag_weights](events, jet_mask=jet_mask, **kwargs)
 
         # FIXME: not all weights are available for run 3

--- a/mtt/reduction/__init__.py
+++ b/mtt/reduction/__init__.py
@@ -1,0 +1,1 @@
+# coding: utf-8

--- a/mtt/reduction/default.py
+++ b/mtt/reduction/default.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+from columnflow.reduction import Reducer, reducer
+from columnflow.reduction.default import cf_default
+from columnflow.util import maybe_import
+from columnflow.columnar_util import set_ak_column
+
+ak = maybe_import("awkward")
+
+@reducer(
+    uses={cf_default},
+    produces={cf_default},
+)
+def default(self: Reducer, events: ak.Array, selection: ak.Array, **kwargs) -> ak.Array:
+    # run cf's default reduction which handles event selection and collection creation
+    events = self[cf_default](events, selection, **kwargs)
+
+    # store gen level information of the remaining events
+    if self.dataset_inst.has_tag("is_sm_ttbar"):
+        events = self[gen_parton_top](events, **kwargs)
+
+    if self.dataset_inst.has_tag("is_v_jets"):
+        events = self[gen_v_boson](events, **kwargs)
+
+    return events

--- a/mtt/reduction/default.py
+++ b/mtt/reduction/default.py
@@ -5,11 +5,22 @@ from columnflow.reduction.default import cf_default
 from columnflow.util import maybe_import
 from columnflow.columnar_util import set_ak_column
 
+from mtt.production.gen_top import gen_parton_top
+from mtt.production.gen_v import gen_v_boson
+
 ak = maybe_import("awkward")
 
 @reducer(
-    uses={cf_default},
-    produces={cf_default},
+    uses={
+        cf_default,
+        gen_parton_top,
+        gen_v_boson,
+    },
+    produces={
+        cf_default,
+        gen_parton_top,
+        gen_v_boson,
+    },
 )
 def default(self: Reducer, events: ak.Array, selection: ak.Array, **kwargs) -> ak.Array:
     # run cf's default reduction which handles event selection and collection creation

--- a/mtt/selection/default.py
+++ b/mtt/selection/default.py
@@ -27,8 +27,10 @@ from mtt.selection.jets import met_selection
 from mtt.selection.qcd_spikes import qcd_spikes
 from mtt.selection.data_trigger_veto import data_trigger_veto
 
-from mtt.production.gen_top import gen_parton_top
-from mtt.production.gen_v import gen_v_boson
+from mtt.util import print_log_msg
+
+# from mtt.production.gen_top import gen_parton_top
+# from mtt.production.gen_v import gen_v_boson
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -44,8 +46,8 @@ ak = maybe_import("awkward")
         process_ids, increment_stats, attach_coffea_behavior,
         mc_weight,
         met_filters,
-        gen_parton_top,
-        gen_v_boson,
+        # gen_parton_top,
+        # gen_v_boson,
         json_filter,
     },
     produces={
@@ -57,8 +59,8 @@ ak = maybe_import("awkward")
         process_ids, increment_stats, attach_coffea_behavior,
         mc_weight,
         met_filters,
-        gen_parton_top,
-        gen_v_boson,
+        # gen_parton_top,
+        # gen_v_boson,
         json_filter,
     },
     shifts={
@@ -125,29 +127,37 @@ def default(
 
     for step, sel in results.steps.items():
         n_sel = ak.sum(sel, axis=-1)
-        print(f"{step}: {n_sel}")
+        print_log_msg(f"{step}: {n_sel}", print_msg=True)
 
     n_sel = ak.sum(event_sel, axis=-1)
-    print(f"__all__: {n_sel}")
+    print_log_msg(f"__all__: {n_sel}", print_msg=True)
 
-    # produce features relevant for selection and event weights
-    if self.dataset_inst.has_tag("is_sm_ttbar"):
-        events = self[gen_parton_top](events, **kwargs)
+    # # produce features relevant for selection and event weights
+    # if self.dataset_inst.has_tag("is_sm_ttbar"):
+    #     # TODO: add gen-level features at reduction step
+    #     print_log_msg("Storing gen-level features for SM ttbar")
+    #     events = self[gen_parton_top](events, **kwargs)
 
-    if self.dataset_inst.has_tag("is_v_jets"):
-        events = self[gen_v_boson](events, **kwargs)
+    # if self.dataset_inst.has_tag("is_v_jets"):
+    #     # TODO: add gen-level features at reduction step
+    #     print_log_msg("Generating gen-level features for V+jets")
+    #     events = self[gen_v_boson](events, **kwargs)
 
     # add cutflow features
+    print_log_msg("Storing cutflow features", print_msg=False)
     events = self[cutflow_features](events, results=results, **kwargs)
 
     # build categories
+    print_log_msg("Building categories", print_msg=False)
     events = self[category_ids](events, results=results, **kwargs)
 
     # create process ids
+    print_log_msg("Creating process ids", print_msg=False)
     events = self[process_ids](events, **kwargs)
 
     # add mc weights (needed for cutflow plots)
     if self.dataset_inst.is_mc:
+        print_log_msg("Adding MC weights", print_msg=False)
         events = self[mc_weight](events, **kwargs)
 
     # increment stats
@@ -182,6 +192,9 @@ def default(
                 "mask_fn": (lambda v: events.process_id == v),
             },
         }
+
+    # increment stats
+    print_log_msg("Incrementing stats", print_msg=False)
     events, results = self[increment_stats](
         events,
         results,

--- a/mtt/util.py
+++ b/mtt/util.py
@@ -33,3 +33,17 @@ def iter_chunks(*arrays, max_chunk_size):
         slc = slice(i_chunk * max_chunk_size, end)
 
         yield tuple(a[slc] for a in arrays)
+
+
+def print_log_msg(
+        msg: str,
+        print_msg: bool = False,
+) -> None:
+    """
+    Print a log message if `print_msg` is True.
+    """
+    if print_msg:
+        print(msg)
+    else:
+        # in case of no printing, we could log it to a file or similar
+        pass  # Placeholder for future logging implementation

--- a/workflow_scripts/test_workflow.sh
+++ b/workflow_scripts/test_workflow.sh
@@ -8,13 +8,15 @@ version=test_updates_250417
 analysis=mtt.config.run3.analysis_mtt.analysis_mtt
 config=run3_mtt_2022_preEE_nano_v12_limited
 calibrator=skip_jecunc
+selector=default
+reducer=default
 
 datasets_str=$(IFS=,; echo "${datasets[*]}")
 datasets_mc_str=$(IFS=,; echo "${datasets_mc[*]}")
 
 # process datasets
-# for dataset in "${datasets[@]}"; do
-for dataset in tt_sl_powheg; do
+for dataset in "${datasets[@]}"; do
+# for dataset in $datasets_str; do
     echo "Processing dataset: $dataset"
     echo law run cf.CalibrateEvents \
     --version $version \
@@ -27,21 +29,34 @@ for dataset in tt_sl_powheg; do
     --analysis $analysis \
     --config $config \
     --dataset $dataset \
-    --calibrators $calibrator
+    --calibrators $calibrator \
+    --selector $selector
+    echo law run cf.ReduceEvents \
+    --version $version \
+    --analysis $analysis \
+    --config $config \
+    --dataset $dataset \
+    --calibrators $calibrator \
+    --selector $selector \
+    --reducer $reducer
     echo law run cf.ProduceColumns \
     --version $version \
     --analysis $analysis \
     --config $config \
     --dataset $dataset \
     --calibrators $calibrator \
-    --producer ttbar
+    --producer ttbar \
+    --selector $selector \
+    --reducer $reducer
     echo law run cf.ProduceColumns \
     --version $version \
     --analysis $analysis \
     --config $config \
     --dataset $dataset \
     --calibrators $calibrator \
-    --producer features
+    --producer features \
+    --selector $selector \
+    --reducer $reducer
     # don't run weights for data
     if [[ $dataset == data* ]]; then
         continue
@@ -52,7 +67,9 @@ for dataset in tt_sl_powheg; do
     --config $config \
     --dataset $dataset \
     --calibrators $calibrator \
-    --producer weights
+    --producer weights \
+    --selector $selector \
+    --reducer $reducer
 done
 
 # plot cutflow of mc samples  # FIXME not working
@@ -107,9 +124,11 @@ law run cf.PlotVariables1D \
     --remove-output 0,a,y \
     --shape-norm \
     --plot-suffix norm \
-    --workers 10 \
-    --workflow htcondor \
-    --local-scheduler false
+    --workers 1 \
+    --workflow local \
+    --local-scheduler false \
+    --selector $selector \
+    --reducer $reducer
 
 # plot pt of muon and electron in 1e and 1m - not normalized
 # law run cf.PlotVariables1D \


### PR DESCRIPTION
This PR includes the necessary fixes to the updated version of columnflow which introduced breaking changes. Since the refactoring in columnflow is not yet finalised, things might still change and need additional adjustments. The commands in the [testing_script](https://github.com/uhh-cms/mttbar/blob/update/cf_taf/workflow_scripts/test_workflow.sh) have been used for testing the changes. Note two things:

1. The machine learning (ML) branch has not been tested yet.
2. Some commands needed changes due to the columnflow update. For details, have a look at the [transition guide](https://columnflow.readthedocs.io/en/refactor-taf_init/user_guide/02_03_transition.html) provided by the columnflow team.

In addition, this pull request introduces several updates across multiple files to improve dataset configurations, enhance production and reduction workflows, and fix or optimize code. The key changes include dataset updates, configuration adjustments for production and reduction modules.

### Dataset and Configuration Updates:
* Updated the default dataset in `law.cfg` to `tt_sl_powheg` and adjusted the dataset file limits for both Run2 and Run3 configs from 1 to 2 to also test merging tasks.

### Production and Reduction Changes:
* Introduced a new reducer, `default`, in `mtt/reduction/default.py`, which integrates the `cf_default` reducer to handle event reduction while adding gen-level information for specific datasets. This is not yet working and to be finalised.
* Added a new producer, `add_prod_cats`, in `mtt/production/ttbar_reco.py` to manage production categories, along with related setup, initialization, and requirements methods. The previous implementation broke and this is now also easier to debug. Now, the ```add_prod_cats``` producer requires the ```ttbar``` producer to have output. Therefore, one needs to call it instead of the ```ttbar``` producer on command line. Since the ML based categories are implemented in a similar way, we might need to adapt the code there as well.
* Updated default settings in Run2 and Run3 configurations to include `cf_default` as the default reducer and histogram producer.

### Codebase Fixes:
* Replaced direct references to `self.task` with `task` in `mtt/production/ttbar_reco.py` to fix broken behavior.
* Updated imports across multiple files to resolve dependency issues and improve modularity

I suggest waiting with merging this PR until the columnflow transition is more or less finalised, but feel free to test the current state and give feedback.