### PR TITLE
Setup 2024 config

### DIFF
--- a/law.cfg
+++ b/law.cfg
@@ -36,7 +36,7 @@ skip_ensure_proxy: False
 
 # some remote workflow parameter defaults
 htcondor_flavor: naf
-htcondor_share_software: False
+htcondor_share_software: True
 slurm_flavor: maxwell
 slurm_partition: $CF_SLURM_PARTITION
 
@@ -132,7 +132,8 @@ base: &::xrootd_base
 
 xrootd_base: root://dcache-cms-xrootd.desy.de:1094/pnfs/desy.de/cms/tier2
 gsiftp_base: gsiftp://dcache-door-cms04.desy.de:2811/pnfs/desy.de/cms/tier2
-base: &::xrootd_base
+webdav_base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2
+base: &::webdav_base
 use_cache: $CF_WLCG_USE_CACHE
 cache_root: $CF_WLCG_CACHE_ROOT
 cache_cleanup: $CF_WLCG_CACHE_CLEANUP

--- a/mtt/calibration/default.py
+++ b/mtt/calibration/default.py
@@ -6,6 +6,9 @@ Calibration methods.
 
 from columnflow.calibration import Calibrator, calibrator
 from columnflow.calibration.cms.jets import jets
+# TODO should we add these later?
+# from columnflow.calibration.cms.egamma import electron_scale_smear
+# from columnflow.calibration.cms.muon import muon_sr
 from columnflow.production.cms.mc_weight import mc_weight
 from columnflow.production.cms.seeds import deterministic_seeds
 from columnflow.util import maybe_import

--- a/mtt/config/categories.py
+++ b/mtt/config/categories.py
@@ -111,7 +111,7 @@ def add_categories_selection(config: od.Config) -> None:
         "n_top_tags": CategoryGroup(["0t", "1t"], is_complete=False, has_overlap=False),
     }
 
-    create_category_combinations(config, category_groups, name_fn, kwargs_fn)
+    create_category_combinations(config, category_groups, name_fn, kwargs_fn=kwargs_fn, parent_mode="safe")
 
 
 def add_categories_production(config: od.Config) -> None:
@@ -176,7 +176,7 @@ def add_categories_production(config: od.Config) -> None:
         ),
     }
 
-    create_category_combinations(config, category_groups, name_fn, kwargs_fn)
+    create_category_combinations(config, category_groups, name_fn, kwargs_fn=kwargs_fn, parent_mode="all")
 
 
 def add_categories_ml(config: od.Config, ml_model_inst: MLModel) -> None:
@@ -262,6 +262,7 @@ def add_categories_ml(config: od.Config, ml_model_inst: MLModel) -> None:
         config,
         category_groups,
         name_fn,
-        kwargs_fn_dnn,
+        kwargs_fn=kwargs_fn_dnn,
         skip_existing=True,
+        parent_mode="all",
     )

--- a/mtt/config/corrections.py
+++ b/mtt/config/corrections.py
@@ -7,9 +7,12 @@ Configuration of corrections for the m(ttbar) analysis.
 import order as od
 
 from columnflow.util import DotDict
+from columnflow.production.cms.btag import BTagSFConfig
+from columnflow.production.cms.electron import ElectronSFConfig
+from columnflow.production.cms.muon import MuonSFConfig
 
 
-def vjets_reweighting(
+def vjets_reweighting_cfg(
 ) -> DotDict:
 
     kfactors = {
@@ -26,7 +29,7 @@ def vjets_reweighting(
     return DotDict.wrap(kfactors)
 
 
-def jerc(
+def jerc_cfg(
         campaign: od.Campaign,
         year: int = None,
 ) -> list[DotDict]:
@@ -42,15 +45,15 @@ def jerc(
         jer_campaign = f"Summer23{jerc_postfix}Prompt23_Run{era}"
         jec_campaign = f"Summer23{jerc_postfix}Prompt23"
     elif year == 2024:
-        jec_campaign = f"Summer24Prompt24"
-        jer_campaign = f"Summer23BPixPrompt23_RunD"  # no 2024 JER yet, use 2023 BPix
+        jec_campaign = "Summer24Prompt24"
+        jer_campaign = "Summer23BPixPrompt23_RunD"  # no 2024 JER yet, use 2023 BPix: https://cms-jerc.web.cern.ch/Recommendations/#2024_1 # noqa
 
     jet_type = "AK4PFPuppi"
     fatjet_type = "AK8PFPuppi"
     jec_ak4_version = jec_ak8_version = {
         2022: "V3",
         2023: "V3",
-        2024: "V1",
+        2024: "V2",
     }[year]
 
     jec_params = {
@@ -118,7 +121,7 @@ def jerc(
                 # "CorrelationGroupFlavor",
                 # "CorrelationGroupUncorrelated",
             ],
-            "data_per_era": False if year == 2023 else True,
+            "data_per_era": False if year in [2023, 2024] else True,  # 2022 JEC has the era in the correction set name
         },
         "FatJet": {
             "campaign": jec_campaign,
@@ -184,7 +187,7 @@ def jerc(
                 # "CorrelationGroupFlavor",
                 # "CorrelationGroupUncorrelated",
             ],
-            "data_per_era": False if year == 2023 else True,
+            "data_per_era": False if year in [2023, 2024] else True,  # 2022 JEC has the era in the correction set name
         },
         "SubJet": {
             "campaign": jec_campaign,
@@ -250,7 +253,7 @@ def jerc(
                 # "CorrelationGroupFlavor",
                 # "CorrelationGroupUncorrelated",
             ],
-            "data_per_era": False if year == 2023 else True,
+            "data_per_era": False if year in [2023, 2024] else True,  # 2022 JEC has the era in the correction set name
         },
     }
 
@@ -277,10 +280,11 @@ def jerc(
     return [DotDict.wrap(jec_params), DotDict.wrap(jer_params)]
 
 
-def btag_sf(
+def btag_sf_cfg(
         year: int = None,
 ) -> list[tuple, list]:
-    name = ("deepJet_shape")
+    name = ("deepJet_shape") if year != 2024 else ("UParTAK4_kinfit")
+    discr = "btagPNetB" if year != 2024 else "btagUParTAK4B"
     jec_sources = [
         "",  # same as "Total"
         "Absolute",
@@ -320,11 +324,23 @@ def btag_sf(
         "SinglePionHCAL",
         "TimePtEta",
     ]
+    if year == 2024:
+        systematics = [
+            "central",
+            # "fsrdef", "hdamp", "isrdef", "jer", "jes", "mass",
+            # "statistic", "tune",
+        ]
+    btag_sf_config = BTagSFConfig(
+        correction_set=name,
+        jec_sources=jec_sources,
+        discriminator=discr,
+        corrector_kwargs={"working_point": "M", "flavor": 5} if year == 2024 else {"working_point": "medium"},
+    )
 
-    return (name, jec_sources)
+    return btag_sf_config
 
 
-def toptag_sf(
+def toptag_sf_cfg(
 ) -> DotDict:
     # TODO: use PNet!
     name = {
@@ -335,7 +351,7 @@ def toptag_sf(
     return DotDict.wrap(name)
 
 
-def lepton_sf(
+def lepton_sf_cfg(
         config: od.Config,
         lepton: str = None,
 ) -> list:
@@ -343,11 +359,11 @@ def lepton_sf(
     run = config.campaign.x.run
     tag = config.x.cpn_tag
 
-    lepton_sf = {
+    lepton_sf_dict = {
         3: {
             "2022preEE": {
                 "electron": {
-                    "sf_names": (
+                    "id_sf_names": (
                         "Electron-ID-SF",
                         "2022Re-recoBCD",
                         "Tight",
@@ -370,7 +386,7 @@ def lepton_sf(
             },
             "2022postEE": {
                 "electron": {
-                    "sf_names": (
+                    "id_sf_names": (
                         "Electron-ID-SF",
                         "2022Re-recoE+PromptFG",
                         "Tight",
@@ -393,7 +409,7 @@ def lepton_sf(
             },
             "2023preBPix": {
                 "electron": {
-                    "sf_names": (
+                    "id_sf_names": (
                         "Electron-ID-SF",
                         "2023PromptC",
                         "Tight",
@@ -416,7 +432,7 @@ def lepton_sf(
             },
             "2023postBPix": {
                 "electron": {
-                    "sf_names": (
+                    "id_sf_names": (
                         "Electron-ID-SF",
                         "2023PromptD",
                         "Tight",
@@ -439,11 +455,16 @@ def lepton_sf(
             },
             "2024": {
                 "electron": {
-                    "sf_names": (
+                    "id_sf_names": (
                         "Electron-ID-SF",
-                        "2024Prompt24",
+                        "2024Prompt",
                         "Tight",
-                    )
+                    ),
+                    "reco_sf_names": (
+                        "Electron-ID-SF",
+                        "2024Prompt",
+                        ["RecoBelow20", "Reco20to75", "RecoAbove75"],
+                    ),
                 },
                 "muon": {
                     "sf_names": (
@@ -463,6 +484,76 @@ def lepton_sf(
         }
     }
 
-    return DotDict.wrap(
-        lepton_sf[run][tag][lepton]
+    if lepton == "electron":
+        # electron_id_sf_config = ElectronSFConfig(
+        #     correction=lepton_sf_dict[run][tag][lepton]["id_sf_names"][0],
+        #     campaign=lepton_sf_dict[run][tag][lepton]["id_sf_names"][1],
+        #     working_point="wp80iso",  # taken from hbt config
+        # )
+        electron_reco_id_sf_config = ElectronSFConfig(
+            correction=lepton_sf_dict[run][tag][lepton]["reco_sf_names"][0],
+            campaign=lepton_sf_dict[run][tag][lepton]["reco_sf_names"][1],
+            working_point={
+                "wp80iso": (lambda variables: variables["pt"] > 10.0),
+                "RecoBelow20": (lambda variables: variables["pt"] < 20.0),
+                "Reco20to75": (lambda variables: (variables["pt"] >= 20.0) & (variables["pt"] < 75.0)),
+                "RecoAbove75": (lambda variables: variables["pt"] >= 75.0),
+            },
+        )
+        return electron_reco_id_sf_config
+
+    elif lepton == "muon":
+        muon_sf_config = MuonSFConfig(
+            correction=lepton_sf_dict[run][tag][lepton]["sf_names"][0],
+            # campaign=run,
+        )
+        muon_id_config = MuonSFConfig(
+            correction=lepton_sf_dict[run][tag][lepton]["id_sf_names"][0],
+            # campaign=run,
+        )
+        muon_iso_config = MuonSFConfig(
+            correction=lepton_sf_dict[run][tag][lepton]["iso_sf_names"][0],
+            # campaign=run,
+        )
+        return [muon_sf_config, muon_id_config, muon_iso_config]
+
+
+def met_phi_cfg(
+        config: od.Config
+):
+    met_column = config.x.met_selection.column
+    # raw_met_column = config.x.met_selection.raw_column
+
+    from columnflow.calibration.cms.met import METPhiConfig
+    met_config = METPhiConfig(
+        met_name=met_column,
+        met_type=met_column,
+        correction_set="met_xy_corrections",
+        keep_uncorrected=True,  # TODO do we need this?
+        pt_phi_variations={
+            "stat_xdn": "metphi_statx_down",
+            "stat_xup": "metphi_statx_up",
+            "stat_ydn": "metphi_staty_down",
+            "stat_yup": "metphi_staty_up",
+        },
+        variations={
+            "pu_dn": "minbias_xs_down",
+            "pu_up": "minbias_xs_up",
+        },
     )
+    return met_config
+
+
+def jet_id_cfg():
+    from columnflow.production.cms.jet import JetIdConfig
+    jet_id_config = JetIdConfig(
+        corrections={"AK4PUPPI_Tight": 2, "AK4PUPPI_TightLeptonVeto": 3}
+    )
+    fatjet_id_config = JetIdConfig(
+        corrections={"AK8PUPPI_Tight": 2, "AK8PUPPI_TightLeptonVeto": 3}
+    )
+
+    return DotDict.wrap({
+        "Jet": jet_id_config,
+        "FatJet": fatjet_id_config,
+    })

--- a/mtt/config/corrections.py
+++ b/mtt/config/corrections.py
@@ -1,0 +1,468 @@
+# coding: utf-8
+
+"""
+Configuration of corrections for the m(ttbar) analysis.
+"""
+
+import order as od
+
+from columnflow.util import DotDict
+
+
+def vjets_reweighting(
+) -> DotDict:
+
+    kfactors = {
+        "w": {
+            "value": "wjets_kfactor_value",
+            "error": "wjets_kfactor_error",
+        },
+        "z": {
+            "value": "zjets_kfactor_value",
+            "error": "zjets_kfactor_error",
+        },
+    }
+
+    return DotDict.wrap(kfactors)
+
+
+def jerc(
+        campaign: od.Campaign,
+        year: int = None,
+) -> list[DotDict]:
+    # https://cms-jerc.web.cern.ch/Recommendations/#jet-energy-scale
+
+    jerc_postfix = campaign.x.postfix
+    if jerc_postfix not in ("", "EE", "BPix"):
+        raise ValueError(f"Invalid JERC postfix '{jerc_postfix}' for campaign {campaign.name}.")
+    if year == 2022:
+        jer_campaign = jec_campaign = f"Summer22{jerc_postfix}_22Sep2023"
+    elif year == 2023:
+        era = "Cv1234" if campaign.has_tag("preBPix") else "D"
+        jer_campaign = f"Summer23{jerc_postfix}Prompt23_Run{era}"
+        jec_campaign = f"Summer23{jerc_postfix}Prompt23"
+    elif year == 2024:
+        jec_campaign = f"Summer24Prompt24"
+        jer_campaign = f"Summer23BPixPrompt23_RunD"  # no 2024 JER yet, use 2023 BPix
+
+    jet_type = "AK4PFPuppi"
+    fatjet_type = "AK8PFPuppi"
+    jec_ak4_version = jec_ak8_version = {
+        2022: "V3",
+        2023: "V3",
+        2024: "V1",
+    }[year]
+
+    jec_params = {
+        "Jet": {
+            "campaign": jec_campaign,
+            "version": jec_ak4_version,
+            "jet_type": jet_type,
+            "levels": ["L1FastJet", "L2Relative", "L2L3Residual", "L3Absolute"],
+            "levels_for_type1_met": ["L1FastJet"],
+            "uncertainty_sources": [
+                # "AbsoluteStat",
+                # "AbsoluteScale",
+                # "AbsoluteSample",
+                # "AbsoluteFlavMap",
+                # "AbsoluteMPFBias",
+                # "Fragmentation",
+                # "SinglePionECAL",
+                # "SinglePionHCAL",
+                # "FlavorQCD",
+                # "TimePtEta",
+                # "RelativeJEREC1",
+                # "RelativeJEREC2",
+                # "RelativeJERHF",
+                # "RelativePtBB",
+                # "RelativePtEC1",
+                # "RelativePtEC2",
+                # "RelativePtHF",
+                # "RelativeBal",
+                # "RelativeSample",
+                # "RelativeFSR",
+                # "RelativeStatFSR",
+                # "RelativeStatEC",
+                # "RelativeStatHF",
+                # "PileUpDataMC",
+                # "PileUpPtRef",
+                # "PileUpPtBB",
+                # "PileUpPtEC1",
+                # "PileUpPtEC2",
+                # "PileUpPtHF",
+                # "PileUpMuZero",
+                # "PileUpEnvelope",
+                # "SubTotalPileUp",
+                # "SubTotalRelative",
+                # "SubTotalPt",
+                # "SubTotalScale",
+                # "SubTotalAbsolute",
+                # "SubTotalMC",
+                "Total",
+                # "TotalNoFlavor",
+                # "TotalNoTime",
+                # "TotalNoFlavorNoTime",
+                # "FlavorZJet",
+                # "FlavorPhotonJet",
+                # "FlavorPureGluon",
+                # "FlavorPureQuark",
+                # "FlavorPureCharm",
+                # "FlavorPureBottom",
+                # "TimeRunA",
+                # "TimeRunB",
+                # "TimeRunC",
+                # "TimeRunD",
+                # "CorrelationGroupMPFInSitu",
+                # "CorrelationGroupIntercalibration",
+                # "CorrelationGroupbJES",
+                # "CorrelationGroupFlavor",
+                # "CorrelationGroupUncorrelated",
+            ],
+            "data_per_era": False if year == 2023 else True,
+        },
+        "FatJet": {
+            "campaign": jec_campaign,
+            "version": jec_ak8_version,
+            "jet_type": fatjet_type,
+            "levels": ["L1FastJet", "L2Relative", "L2L3Residual", "L3Absolute"],
+            "levels_for_type1_met": ["L1FastJet"],
+            "uncertainty_sources": [
+                # "AbsoluteStat",
+                # "AbsoluteScale",
+                # "AbsoluteSample",
+                # "AbsoluteFlavMap",
+                # "AbsoluteMPFBias",
+                # "Fragmentation",
+                # "SinglePionECAL",
+                # "SinglePionHCAL",
+                # "FlavorQCD",
+                # "TimePtEta",
+                # "RelativeJEREC1",
+                # "RelativeJEREC2",
+                # "RelativeJERHF",
+                # "RelativePtBB",
+                # "RelativePtEC1",
+                # "RelativePtEC2",
+                # "RelativePtHF",
+                # "RelativeBal",
+                # "RelativeSample",
+                # "RelativeFSR",
+                # "RelativeStatFSR",
+                # "RelativeStatEC",
+                # "RelativeStatHF",
+                # "PileUpDataMC",
+                # "PileUpPtRef",
+                # "PileUpPtBB",
+                # "PileUpPtEC1",
+                # "PileUpPtEC2",
+                # "PileUpPtHF",
+                # "PileUpMuZero",
+                # "PileUpEnvelope",
+                # "SubTotalPileUp",
+                # "SubTotalRelative",
+                # "SubTotalPt",
+                # "SubTotalScale",
+                # "SubTotalAbsolute",
+                # "SubTotalMC",
+                "Total",
+                # "TotalNoFlavor",
+                # "TotalNoTime",
+                # "TotalNoFlavorNoTime",
+                # "FlavorZJet",
+                # "FlavorPhotonJet",
+                # "FlavorPureGluon",
+                # "FlavorPureQuark",
+                # "FlavorPureCharm",
+                # "FlavorPureBottom",
+                # "TimeRunA",
+                # "TimeRunB",
+                # "TimeRunC",
+                # "TimeRunD",
+                # "CorrelationGroupMPFInSitu",
+                # "CorrelationGroupIntercalibration",
+                # "CorrelationGroupbJES",
+                # "CorrelationGroupFlavor",
+                # "CorrelationGroupUncorrelated",
+            ],
+            "data_per_era": False if year == 2023 else True,
+        },
+        "SubJet": {
+            "campaign": jec_campaign,
+            "version": jec_ak4_version,
+            "jet_type": jet_type,
+            "levels": ["L1FastJet", "L2Relative", "L2L3Residual", "L3Absolute"],
+            "levels_for_type1_met": ["L1FastJet"],
+            "uncertainty_sources": [
+                # "AbsoluteStat",
+                # "AbsoluteScale",
+                # "AbsoluteSample",
+                # "AbsoluteFlavMap",
+                # "AbsoluteMPFBias",
+                # "Fragmentation",
+                # "SinglePionECAL",
+                # "SinglePionHCAL",
+                # "FlavorQCD",
+                # "TimePtEta",
+                # "RelativeJEREC1",
+                # "RelativeJEREC2",
+                # "RelativeJERHF",
+                # "RelativePtBB",
+                # "RelativePtEC1",
+                # "RelativePtEC2",
+                # "RelativePtHF",
+                # "RelativeBal",
+                # "RelativeSample",
+                # "RelativeFSR",
+                # "RelativeStatFSR",
+                # "RelativeStatEC",
+                # "RelativeStatHF",
+                # "PileUpDataMC",
+                # "PileUpPtRef",
+                # "PileUpPtBB",
+                # "PileUpPtEC1",
+                # "PileUpPtEC2",
+                # "PileUpPtHF",
+                # "PileUpMuZero",
+                # "PileUpEnvelope",
+                # "SubTotalPileUp",
+                # "SubTotalRelative",
+                # "SubTotalPt",
+                # "SubTotalScale",
+                # "SubTotalAbsolute",
+                # "SubTotalMC",
+                "Total",
+                # "TotalNoFlavor",
+                # "TotalNoTime",
+                # "TotalNoFlavorNoTime",
+                # "FlavorZJet",
+                # "FlavorPhotonJet",
+                # "FlavorPureGluon",
+                # "FlavorPureQuark",
+                # "FlavorPureCharm",
+                # "FlavorPureBottom",
+                # "TimeRunA",
+                # "TimeRunB",
+                # "TimeRunC",
+                # "TimeRunD",
+                # "CorrelationGroupMPFInSitu",
+                # "CorrelationGroupIntercalibration",
+                # "CorrelationGroupbJES",
+                # "CorrelationGroupFlavor",
+                # "CorrelationGroupUncorrelated",
+            ],
+            "data_per_era": False if year == 2023 else True,
+        },
+    }
+
+    # JER
+    # https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution?rev=107
+    jer_params = {
+        "Jet": {
+            "campaign": jer_campaign,
+            "version": {2022: "JRV1", 2023: "JRV1", 2024: "JRV1"}[year],
+            "jet_type": jet_type,
+        },
+        "FatJet": {
+            "campaign": jer_campaign,
+            "version": {2022: "JRV1", 2023: "JRV1", 2024: "JRV1"}[year],
+            "jet_type": fatjet_type,
+        },
+        "SubJet": {
+            "campaign": jer_campaign,
+            "version": {2022: "JRV1", 2023: "JRV1", 2024: "JRV1"}[year],
+            "jet_type": jet_type,
+        },
+    }
+
+    return [DotDict.wrap(jec_params), DotDict.wrap(jer_params)]
+
+
+def btag_sf(
+        year: int = None,
+) -> list[tuple, list]:
+    name = ("deepJet_shape")
+    jec_sources = [
+        "",  # same as "Total"
+        "Absolute",
+        "AbsoluteMPFBias",
+        "AbsoluteScale",
+        "AbsoluteStat",
+        f"Absolute_{year}",
+        "BBEC1",
+        f"BBEC1_{year}",
+        "EC2",
+        f"EC2_{year}",
+        "FlavorQCD",
+        "Fragmentation",
+        "HF",
+        f"HF_{year}",
+        "PileUpDataMC",
+        "PileUpPtBB",
+        "PileUpPtEC1",
+        "PileUpPtEC2",
+        "PileUpPtHF",
+        "PileUpPtRef",
+        "RelativeBal",
+        "RelativeFSR",
+        "RelativeJEREC1",
+        "RelativeJEREC2",
+        "RelativeJERHF",
+        "RelativePtBB",
+        "RelativePtEC1",
+        "RelativePtEC2",
+        "RelativePtHF",
+        "RelativeSample",
+        f"RelativeSample_{year}",
+        "RelativeStatEC",
+        "RelativeStatFSR",
+        "RelativeStatHF",
+        "SinglePionECAL",
+        "SinglePionHCAL",
+        "TimePtEta",
+    ]
+
+    return (name, jec_sources)
+
+
+def toptag_sf(
+) -> DotDict:
+    # TODO: use PNet!
+    name = {
+        "name": "DeepAK8_Top_MassDecorr",
+        "wp": "1p0",
+    }
+
+    return DotDict.wrap(name)
+
+
+def lepton_sf(
+        config: od.Config,
+        lepton: str = None,
+) -> list:
+    # TODO: we need to use different SFs for control regions
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    lepton_sf = {
+        3: {
+            "2022preEE": {
+                "electron": {
+                    "sf_names": (
+                        "Electron-ID-SF",
+                        "2022Re-recoBCD",
+                        "Tight",
+                    )
+                },
+                "muon": {
+                    "sf_names": (
+                        "NUM_TightPFIso_DEN_TightID",
+                        "2022preEE",
+                    ),
+                    "id_sf_names": (
+                        "NUM_TightID_DEN_TrackerMuons",
+                        "2022preEE",
+                    ),
+                    "iso_sf_names": (
+                        "NUM_TightPFIso_DEN_TightID",
+                        "2022preEE",
+                    ),
+                }
+            },
+            "2022postEE": {
+                "electron": {
+                    "sf_names": (
+                        "Electron-ID-SF",
+                        "2022Re-recoE+PromptFG",
+                        "Tight",
+                    )
+                },
+                "muon": {
+                    "sf_names": (
+                        "NUM_TightPFIso_DEN_TightID",
+                        "2022postEE",
+                    ),
+                    "id_sf_names": (
+                        "NUM_TightID_DEN_TrackerMuons",
+                        "2022postEE",
+                    ),
+                    "iso_sf_names": (
+                        "NUM_TightPFIso_DEN_TightID",
+                        "2022postEE",
+                    ),
+                },
+            },
+            "2023preBPix": {
+                "electron": {
+                    "sf_names": (
+                        "Electron-ID-SF",
+                        "2023PromptC",
+                        "Tight",
+                    )
+                },
+                "muon": {
+                    "sf_names": (
+                        "NUM_TightPFIso_DEN_TightID",
+                        "2023preBPix",
+                    ),
+                    "id_sf_names": (
+                        "NUM_TightID_DEN_TrackerMuons",
+                        "2023preBPix",
+                    ),
+                    "iso_sf_names": (
+                        "NUM_TightPFIso_DEN_TightID",
+                        "2023preBPix",
+                    ),
+                },
+            },
+            "2023postBPix": {
+                "electron": {
+                    "sf_names": (
+                        "Electron-ID-SF",
+                        "2023PromptD",
+                        "Tight",
+                    )
+                },
+                "muon": {
+                    "sf_names": (
+                        "NUM_TightPFIso_DEN_TightID",
+                        "2023postBPix",
+                    ),
+                    "id_sf_names": (
+                        "NUM_TightID_DEN_TrackerMuons",
+                        "2023postBPix",
+                    ),
+                    "iso_sf_names": (
+                        "NUM_TightPFIso_DEN_TightID",
+                        "2023postBPix",
+                    ),
+                },
+            },
+            "2024": {
+                "electron": {
+                    "sf_names": (
+                        "Electron-ID-SF",
+                        "2024Prompt24",
+                        "Tight",
+                    )
+                },
+                "muon": {
+                    "sf_names": (
+                        "NUM_TightPFIso_DEN_TightID",
+                        "2024Prompt24",
+                    ),
+                    "id_sf_names": (
+                        "NUM_TightID_DEN_TrackerMuons",
+                        "2024Prompt24",
+                    ),
+                    "iso_sf_names": (
+                        "NUM_TightPFIso_DEN_TightID",
+                        "2024Prompt24",
+                    ),
+                },
+            },
+        }
+    }
+
+    return DotDict.wrap(
+        lepton_sf[run][tag][lepton]
+    )

--- a/mtt/config/datasets.py
+++ b/mtt/config/datasets.py
@@ -124,6 +124,14 @@ def dy_datasets(
                 "dy_m50to120_ht100to400_madgraph",
                 "dy_m50to120_ht400to800_madgraph",
             ],
+            "2024": [
+                # no HT-binned samples available yet, but in production chain -> to be checked!
+                # https://cms-pdmv-prod.web.cern.ch/grasp/samples?campaign=RunIII2024Summer24*GS&dataset=DYto2*-4J # noqa
+                # using LO samples binned in lepton flavor
+                "dy_4j_mumu_m50toinf_madgraph",
+                "dy_4j_ee_m50toinf_madgraph",
+                # "dy_4j_tautau_m50toinf_madgraph",
+            ]
         }
     }
 
@@ -184,6 +192,26 @@ def w_lnu_datasets(
                 "w_lnu_mlnu0to120_ht1500to2500_madgraph",
                 "w_lnu_mlnu0to120_ht2500toinf_madgraph",
             ],
+            "2024": [
+                # no HT-binned samples available yet, but in production chain -> to be checked!
+                # https://cms-pdmv-prod.web.cern.ch/grasp/samples?campaign=RunIII2024Summer24*GS&dataset=WtoLNu-4Jets_Bin-HT  # noqa
+                # # NLO samples: have very little stats in our phasespace -> use LO samples
+                # "w_lnu_1j_pt40to100_amcatnlo",
+                # "w_lnu_1j_pt100to200_amcatnlo",
+                # "w_lnu_1j_pt200to400_amcatnlo",
+                # "w_lnu_1j_pt400to600_amcatnlo",
+                # "w_lnu_1j_pt600toinf_amcatnlo",
+                # "w_lnu_2j_pt40to100_amcatnlo",
+                # "w_lnu_2j_pt100to200_amcatnlo",
+                # "w_lnu_2j_pt200to400_amcatnlo",
+                # "w_lnu_2j_pt400to600_amcatnlo",
+                # "w_lnu_2j_pt600toinf_amcatnlo",
+                # LO samples binned in jet multiplicity only
+                "w_lnu_1j_madgraph",
+                "w_lnu_2j_madgraph",
+                "w_lnu_3j_madgraph",
+                "w_lnu_4j_madgraph",
+            ]
         }
     }
     try:
@@ -359,7 +387,7 @@ def st_datasets(
                 "st_twchannel_t_sl_powheg",
                 "st_twchannel_tbar_sl_powheg",
                 "st_twchannel_t_dl_powheg",
-                "st_twchannel_tbar_dl_powheg",
+                # "st_twchannel_tbar_dl_powheg",
                 "st_twchannel_t_fh_powheg",
                 "st_twchannel_tbar_fh_powheg",
             ],
@@ -431,6 +459,19 @@ def qcd_datasets(
                 "qcd_ht1500to2000_madgraph",
                 "qcd_ht2000toinf_madgraph",
             ],
+            "2024": [
+                # "qcd_ht40to70_madgraph",  # FIXME empty after selection (lim. config)
+                # "qcd_ht70to100_madgraph",  # FIXME empty after selection (lim. config)
+                # "qcd_ht100to200_madgraph",  # FIXME empty after selection (lim. config)
+                "qcd_ht200to400_madgraph",
+                "qcd_ht400to600_madgraph",
+                "qcd_ht600to800_madgraph",
+                "qcd_ht800to1000_madgraph",
+                "qcd_ht1000to1200_madgraph",
+                "qcd_ht1200to1500_madgraph",
+                "qcd_ht1500to2000_madgraph",
+                "qcd_ht2000toinf_madgraph",
+            ]
         },
     }
     try:
@@ -498,8 +539,41 @@ def zprime_datasets(
             "2017": zprime_datasets,
         },
         3: {
-            "2022preEE": zprime_datasets,
-            "2022postEE": zprime_datasets,
+            # FIXME add datasets when available
+            "2022preEE": [],
+            "2022postEE": [],
+            "2023preBPix": [
+                "zprime_tt_m500_w5_madgraph",
+                "zprime_tt_m500_w50_madgraph",
+                "zprime_tt_m500_w150_madgraph",
+                "zprime_tt_m1000_w10_madgraph",
+                "zprime_tt_m1000_w100_madgraph",
+                "zprime_tt_m1000_w300_madgraph",
+                "zprime_tt_m1600_w16_madgraph",
+                "zprime_tt_m1800_w180_madgraph",
+                "zprime_tt_m5000_w50_madgraph",
+                "zprime_tt_m5000_w500_madgraph",
+                "zprime_tt_m5000_w1500_madgraph",
+                "zprime_tt_m6000_w600_madgraph",
+                "zprime_tt_m8000_w2400_madgraph",
+            ],
+            "2023postBPix": [
+                "zprime_tt_m500_w5_madgraph",
+                "zprime_tt_m500_w50_madgraph",
+                "zprime_tt_m500_w150_madgraph",
+                "zprime_tt_m1000_w10_madgraph",
+                "zprime_tt_m1000_w100_madgraph",
+                "zprime_tt_m1000_w300_madgraph",
+                "zprime_tt_m5000_w50_madgraph",
+                "zprime_tt_m5000_w500_madgraph",
+                "zprime_tt_m5000_w1500_madgraph",
+                "zprime_tt_m7000_w2100_madgraph",
+            ],
+            "2024": [
+                "zprime_tt_m500_w5_madgraph",
+                "zprime_tt_m5000_w1500_madgraph",
+                "zprime_tt_m7000_w70_madgraph",
+            ],
         }
     }
 

--- a/mtt/config/datasets.py
+++ b/mtt/config/datasets.py
@@ -1,0 +1,691 @@
+# coding: utf-8
+
+"""
+Configuration of datasets for the m(ttbar) analysis.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import order as od
+
+from mtt.util import print_log_msg
+
+
+def data_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False,
+) -> None:
+    """
+    Adds data datasets to the config based on the run number and campaign tag.
+    """
+    if config.campaign.x.run == 2:
+        config.x.data_streams = [
+            "mu",
+            "e",
+            "pho",
+        ]
+    elif config.campaign.x.run == 3:
+        config.x.data_streams = [
+            "mu",
+            "egamma",
+        ]
+    else:
+        raise ValueError(f"Unsupported run number: {config.campaign.x.run}")
+
+    data_eras = {
+        "2017": list("cdef"),
+        "2022preEE": list("cd"),
+        "2022postEE": list("efg"),
+        "2023preBPix": ["c1", "c2", "c3", "c4"],
+        "2023postBPix": ["d1", "d2"],
+        "2024": list("cdefghi")
+    }[config.x.cpn_tag]
+
+    data_datasets = [
+        f"data_{stream}_{era}"
+        for era in data_eras
+        for stream in config.x.data_streams
+    ]
+
+    for dataset in data_datasets:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+
+        ds.add_tag("is_data")
+
+        # if config.campaign.x.run == 3:
+        #     if dataset.endswith("c") or dataset.endswith("d"):
+        #         ds.x.jec_era = "RunCD"
+
+        if ds.name.startswith("data_mu"):
+            ds.add_tag("is_mu_data")
+        if ds.name.startswith("data_e"):
+            ds.add_tag({"is_e_data", "is_egamma_data"})
+        if ds.name.startswith("data_pho"):
+            ds.add_tag({"is_pho_data", "is_egamma_data"})
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)
+
+    print_log_msg(f"Added {len(data_datasets)} data datasets.", log)
+
+
+def dy_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False
+) -> None:
+    """
+    Adds DY+jets datasets to the config based on the run number and campaign tag.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    datasets = {
+        2: {
+            "2017": [
+                "dy_m50toinf_ht70to100_madgraph",
+                "dy_m50toinf_ht100to200_madgraph",
+                "dy_m50toinf_ht200to400_madgraph",
+                "dy_m50toinf_ht400to600_madgraph",
+                "dy_m50toinf_ht600to800_madgraph",
+                "dy_m50toinf_ht800to1200_madgraph",
+                "dy_m50toinf_ht1200to2500_madgraph",
+                "dy_m50toinf_ht2500toinf_madgraph",
+            ]
+        },
+        3: {
+            "2022preEE": [
+                "dy_m4to50_ht40to70_madgraph",
+                "dy_m4to50_ht70to100_madgraph",
+                "dy_m4to50_ht100to400_madgraph",
+                "dy_m4to50_ht400to800_madgraph",
+                "dy_m4to50_ht800to1500_madgraph",
+                "dy_m4to50_ht1500to2500_madgraph",
+                "dy_m4to50_ht2500toinf_madgraph",
+                "dy_m50to120_ht40to70_madgraph",
+                "dy_m50to120_ht70to100_madgraph",
+                "dy_m50to120_ht100to400_madgraph",
+                "dy_m50to120_ht400to800_madgraph",
+            ],
+            "2022postEE": [  # Same as preEE
+                "dy_m4to50_ht40to70_madgraph",   # FIXME AssertionError (lim. stat.)
+                "dy_m4to50_ht70to100_madgraph",
+                "dy_m4to50_ht100to400_madgraph",  # FIXME AssertionError (lim. stat.)
+                "dy_m4to50_ht400to800_madgraph",
+                "dy_m4to50_ht800to1500_madgraph",
+                "dy_m4to50_ht1500to2500_madgraph",
+                "dy_m4to50_ht2500toinf_madgraph",
+                "dy_m50to120_ht40to70_madgraph",
+                "dy_m50to120_ht70to100_madgraph",
+                "dy_m50to120_ht100to400_madgraph",
+                "dy_m50to120_ht400to800_madgraph",
+            ],
+        }
+    }
+
+    try:
+        datasets_list = datasets[run][tag]
+    except KeyError:
+        raise ValueError(f"DY - Unsupported run/tag combination: run={run}, tag={tag}")
+
+    for dataset in datasets_list:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+        ds.add_tag({"is_dy", "is_v_jets", "is_z_jets"})
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)
+
+    print_log_msg(f"Added {len(datasets_list)} DY datasets.", log)
+
+
+def w_lnu_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False,
+) -> None:
+    """
+    Adds W+jets datasets to the config based on the run number and campaign tag.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    datasets = {
+        2: {
+            "2017": [
+                "w_lnu_ht70to100_madgraph",
+                "w_lnu_ht100to200_madgraph",
+                "w_lnu_ht200to400_madgraph",
+                "w_lnu_ht400to600_madgraph",
+                "w_lnu_ht600to800_madgraph",
+                "w_lnu_ht800to1200_madgraph",
+                "w_lnu_ht1200to2500_madgraph",
+                "w_lnu_ht2500toinf_madgraph",
+            ]
+        },
+        3: {
+            "2022preEE": [
+                "w_lnu_mlnu0to120_ht40to100_madgraph",
+                "w_lnu_mlnu0to120_ht100to400_madgraph",
+                "w_lnu_mlnu0to120_ht400to800_madgraph",
+                "w_lnu_mlnu0to120_ht800to1500_madgraph",
+                "w_lnu_mlnu0to120_ht1500to2500_madgraph",
+                "w_lnu_mlnu0to120_ht2500toinf_madgraph",
+            ],
+            "2022postEE": [  # Same as preEE
+                "w_lnu_mlnu0to120_ht40to100_madgraph",
+                "w_lnu_mlnu0to120_ht100to400_madgraph",
+                "w_lnu_mlnu0to120_ht400to800_madgraph",
+                "w_lnu_mlnu0to120_ht800to1500_madgraph",
+                "w_lnu_mlnu0to120_ht1500to2500_madgraph",
+                "w_lnu_mlnu0to120_ht2500toinf_madgraph",
+            ],
+        }
+    }
+    try:
+        datasets_list = datasets[run][tag]
+    except KeyError:
+        raise ValueError(f"W+jets - Unsupported run/tag combination: run={run}, tag={tag}")
+
+    for dataset in datasets_list:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+        ds.add_tag({"is_w_lnu", "is_v_jets", "is_w_jets"})
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)
+
+    print_log_msg(f"Added {len(datasets_list)} W+jets datasets.", log)
+
+
+def vv_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False,
+) -> None:
+    """
+    Adds diboson datasets to the config based on the run number and campaign tag.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+    diboson_names = [
+        "ww_pythia",
+        "wz_pythia",
+        "zz_pythia",
+    ]
+    datasets = {
+        2: {
+            "2017": diboson_names,
+        },
+        3: {
+            "2022preEE": diboson_names,
+            "2022postEE": diboson_names,
+            "2023preBPix": diboson_names,
+            "2023postBPix": diboson_names,
+            "2024": diboson_names,
+        }
+    }
+    try:
+        dataset_list = datasets[run][tag]
+    except KeyError:
+        raise ValueError(f"Diboson - Unsupported run/tag combination: run={run}, tag={tag}")
+
+    for dataset in dataset_list:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+        ds.add_tag({"is_vv", "is_diboson"})
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)
+
+    print_log_msg(f"Added {len(dataset_list)} diboson datasets.", log)
+
+
+def tt_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False,
+) -> None:
+    """
+    Adds ttbar datasets to the config based on the run number and campaign tag.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+    tt_names = [
+        "tt_sl_powheg",
+        "tt_dl_powheg",
+        "tt_fh_powheg",
+    ]
+    datasets = {
+        2: {
+            "2017": tt_names,
+        },
+        3: {
+            "2022preEE": tt_names,
+            "2022postEE": tt_names,
+            "2023preBPix": tt_names,
+            "2023postBPix": tt_names,
+            "2024": tt_names,
+        }
+    }
+    try:
+        dataset_list = datasets[run][tag]
+    except KeyError:
+        raise ValueError(f"TTbar - Unsupported run/tag combination: run={run}, tag={tag}")
+
+    for dataset in dataset_list:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+        ds.add_tag({"has_top", "has_ttbar", "is_sm_ttbar"})
+        if ds.name.startswith("tt_sl"):
+            ds.add_tag("has_memory_intensive_reco")
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)
+
+    print_log_msg(f"Added {len(dataset_list)} ttbar datasets.", log)
+
+
+def st_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False,
+) -> None:
+    """
+    Adds single top datasets to the config based on the run number and campaign tag.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    datasets = {
+        2: {
+            "2017": [
+                "st_schannel_lep_4f_amcatnlo",
+                "st_schannel_had_4f_amcatnlo",
+                "st_tchannel_t_4f_powheg",
+                "st_tchannel_tbar_4f_powheg",
+                "st_twchannel_t_powheg",
+                "st_twchannel_tbar_powheg",
+            ]
+        },
+        3: {
+            "2022preEE": [
+                "st_tchannel_t_4f_powheg",
+                "st_tchannel_tbar_4f_powheg",
+                "st_twchannel_t_sl_powheg",
+                "st_twchannel_tbar_sl_powheg",
+                "st_twchannel_t_dl_powheg",
+                "st_twchannel_tbar_dl_powheg",
+                "st_twchannel_t_fh_powheg",
+                "st_twchannel_tbar_fh_powheg",
+            ],
+            "2022postEE": [
+                "st_tchannel_t_4f_powheg",
+                "st_tchannel_tbar_4f_powheg",
+                "st_twchannel_t_sl_powheg",
+                "st_twchannel_tbar_sl_powheg",
+                "st_twchannel_t_dl_powheg",
+                "st_twchannel_tbar_dl_powheg",
+                "st_twchannel_t_fh_powheg",
+                "st_twchannel_tbar_fh_powheg",
+            ],
+            "2023preBPix": [
+                "st_tchannel_t_4f_powheg",
+                "st_tchannel_tbar_4f_powheg",
+                "st_twchannel_t_sl_powheg",
+                "st_twchannel_tbar_sl_powheg",
+                "st_twchannel_t_dl_powheg",
+                "st_twchannel_tbar_dl_powheg",
+                "st_twchannel_t_fh_powheg",
+                "st_twchannel_tbar_fh_powheg",
+            ],
+            "2023postBPix": [
+                "st_tchannel_t_4f_powheg",
+                "st_tchannel_tbar_4f_powheg",
+                "st_twchannel_t_sl_powheg",
+                "st_twchannel_tbar_sl_powheg",
+                "st_twchannel_t_dl_powheg",
+                "st_twchannel_tbar_dl_powheg",
+                "st_twchannel_t_fh_powheg",
+                "st_twchannel_tbar_fh_powheg",
+            ],
+            "2024": [
+                # "st_tchannel_t_4f_powheg",
+                # "st_tchannel_tbar_4f_powheg",
+                "st_twchannel_t_sl_powheg",
+                "st_twchannel_tbar_sl_powheg",
+                "st_twchannel_t_dl_powheg",
+                "st_twchannel_tbar_dl_powheg",
+                "st_twchannel_t_fh_powheg",
+                "st_twchannel_tbar_fh_powheg",
+            ],
+        },
+    }
+    try:
+        dataset_list = datasets[run][tag]
+    except KeyError:
+        raise ValueError(f"Single Top - Unsupported run/tag combination: run={run}, tag={tag}")
+
+    for dataset in dataset_list:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+        ds.add_tag("has_top")
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)
+
+    print_log_msg(f"Added {len(dataset_list)} single top datasets.", log)
+
+
+def qcd_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False,
+) -> None:
+    """
+    Adds QCD datasets to the config based on the run number and campaign tag.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    datasets = {
+        2: {
+            "2017": [
+                "qcd_ht50to100_madgraph",
+                "qcd_ht100to200_madgraph",
+                "qcd_ht200to300_madgraph",
+                "qcd_ht300to500_madgraph",
+                "qcd_ht500to700_madgraph",
+                "qcd_ht700to1000_madgraph",
+                "qcd_ht1000to1500_madgraph",
+                "qcd_ht1500to2000_madgraph",
+                "qcd_ht2000toinf_madgraph",
+            ]
+        },
+        3: {
+            "2022preEE": [
+                "qcd_ht70to100_madgraph",  # FIXME AssertionError (med. stat.)
+                # "qcd_ht100to200_madgraph",  # FIXME no xs for 13.6 in https://xsdb-temp.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS%3DQCD-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8  # noqa
+                "qcd_ht200to400_madgraph",  # FIXME AssertionError (lim. stat.)
+                "qcd_ht400to600_madgraph",
+                "qcd_ht600to800_madgraph",  # FIXME AssertionError (lim. stat.)
+                "qcd_ht800to1000_madgraph",
+                "qcd_ht1000to1200_madgraph",
+                "qcd_ht1200to1500_madgraph",
+                "qcd_ht1500to2000_madgraph",
+                "qcd_ht2000toinf_madgraph",
+            ],
+            "2022postEE": [  # Same as preEE
+                "qcd_ht70to100_madgraph",  # FIXME AssertionError (lim. stat.)
+                # "qcd_ht100to200_madgraph",  # FIXME no xs for 13.6 in https://xsdb-temp.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS%3DQCD-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8  # noqa
+                "qcd_ht200to400_madgraph",  # FIXME AssertionError (lim. stat.)
+                "qcd_ht400to600_madgraph",
+                "qcd_ht600to800_madgraph",  # FIXME AssertionError (lim. stat.)
+                "qcd_ht800to1000_madgraph",
+                "qcd_ht1000to1200_madgraph",
+                "qcd_ht1200to1500_madgraph",
+                "qcd_ht1500to2000_madgraph",
+                "qcd_ht2000toinf_madgraph",
+            ],
+        },
+    }
+    try:
+        dataset_list = datasets[run][tag]
+    except KeyError:
+        raise ValueError(f"QCD - Unsupported run/tag combination: run={run}, tag={tag}")
+
+    for dataset in dataset_list:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+        ds.add_tag("is_qcd")
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)
+
+    print_log_msg(f"Added {len(dataset_list)} QCD datasets.", log)
+
+
+def zprime_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False,
+) -> None:
+    """
+    Adds Z' datasets to the config based on the run number and campaign tag.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    masses = [
+        400,
+        500,
+        600,
+        700,
+        800,
+        900,
+        1000,
+        1200,
+        1400,
+        1600,
+        1800,
+        2000,
+        2500,
+        3000,
+        3500,
+        4000,
+        4500,
+        5000,
+        6000,
+        7000,
+        8000,
+        9000,
+    ]
+    widths = [
+        0.01,
+        0.10,
+        0.30,
+    ]
+    zprime_datasets = [
+        f"zprime_tt_m{mass}_w{int(mass*width)}_madgraph"
+        for mass, width in itertools.product(masses, widths)
+    ]
+    datasets = {
+        2: {
+            "2017": zprime_datasets,
+        },
+        3: {
+            "2022preEE": zprime_datasets,
+            "2022postEE": zprime_datasets,
+        }
+    }
+
+    try:
+        dataset_list = datasets[run][tag]
+    except KeyError:
+        raise ValueError(f"Z' - Unsupported run/tag combination: run={run}, tag={tag}")
+
+    for dataset in dataset_list:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+        ds.add_tag({"is_zprime", "has_top", "has_ttbar", "is_mtt_signal"})
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)
+
+    print_log_msg(f"Added {len(dataset_list)} Z' datasets.", log)
+
+
+def hpseudo_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False,
+) -> None:
+    """
+    Adds hpseudo datasets to the config based on the run number and campaign tag.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    masses = [
+        365,
+        400,
+        500,
+        600,
+        800,
+        1000,
+    ]
+    widths = [
+        0.025,
+        0.1,
+        0.25,
+    ]
+    interference = [
+        "res",  # resonant
+        "int",  # interference
+    ]
+
+    hpseudo_datasets = [
+        f"hpseudo_tt_sl_m{mass}_w{str(width*mass).replace('.', 'p')}_{intf}_madgraph"
+        for mass, width, intf in itertools.product(masses, widths, interference)
+    ]
+    datasets = {
+        2: {
+            "2017": hpseudo_datasets,
+        },
+        3: {
+            "2022preEE": hpseudo_datasets,
+            "2022postEE": hpseudo_datasets,
+        }
+    }
+    try:
+        dataset_list = datasets[run][tag]
+    except KeyError:
+        raise ValueError(f"Hpseudo - Unsupported run/tag combination: run={run}, tag={tag}")
+
+    for dataset in dataset_list:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+        ds.add_tag({"is_hpseudo", "has_top", "has_ttbar", "is_mtt_signal"})
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)
+
+    print_log_msg(f"Added {len(dataset_list)} hpseudo datasets.", log)
+
+
+def hscalar_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False,
+) -> None:
+    """
+    Adds hscalar datasets to the config based on the run number and campaign tag.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    masses = [
+        365,
+        400,
+        500,
+        600,
+        800,
+        1000,
+    ]
+    widths = [
+        0.025,
+        0.1,
+        0.25,
+    ]
+    interference = [
+        "res",  # resonant
+        "int",  # interference
+    ]
+
+    hscalar_datasets = [
+        f"hscalar_tt_sl_m{mass}_w{str(width*mass).replace('.', 'p')}_{intf}_madgraph"
+        for mass, width, intf in itertools.product(masses, widths, interference)
+    ]
+
+    datasets = {
+        2: {
+            "2017": hscalar_datasets,
+        },
+        3: {
+            "2022preEE": hscalar_datasets,
+            "2022postEE": hscalar_datasets,
+        }
+    }
+    try:
+        dataset_list = datasets[run][tag]
+    except KeyError:
+        raise ValueError(f"Hscalar - Unsupported run/tag combination: run={run}, tag={tag}")
+
+    for dataset in dataset_list:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+        ds.add_tag({"is_hscalar", "has_top", "has_ttbar", "is_mtt_signal"})
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)
+
+    print_log_msg(f"Added {len(dataset_list)} hscalar datasets.", log)
+
+
+def rsgluon_datasets(
+        config: od.Config,
+        limit_dataset_files: int | None = None,
+        log: bool = False,
+) -> None:
+    """
+    Returns a list with dataset names for signal RS gluon datasets
+    depending on the run and campaign tag.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    masses = [
+        500,
+        1000,
+        1500,
+        2000,
+        2500,
+        3000,
+        3500,
+        4000,
+        4500,
+        5000,
+        5500,
+        6000,
+    ]
+
+    rsgluon_datasets = [
+        f"rsgluon_tt_m{mass}_pythia"
+        for mass in masses
+    ]
+
+    datasets = {
+        2: {
+            "2017": rsgluon_datasets,
+        },
+        3: {
+            "2022preEE": rsgluon_datasets,
+            "2022postEE": rsgluon_datasets,
+        }
+    }
+    try:
+        dataset_list = datasets[run][tag]
+    except KeyError:
+        raise ValueError(f"RSGluon - Unsupported run/tag combination: run={run}, tag={tag}")
+
+    for dataset in dataset_list:
+        ds = config.add_dataset(config.campaign.get_dataset(dataset))
+        ds.add_tag({"is_rsgluon", "has_top", "has_ttbar", "is_mtt_signal"})
+
+        if limit_dataset_files:
+            for info in ds.info.values():
+                info.n_files = min(info.n_files, limit_dataset_files)

--- a/mtt/config/defaults_and_groups.py
+++ b/mtt/config/defaults_and_groups.py
@@ -1,0 +1,345 @@
+# coding: utf-8
+
+"""
+Configuration of default values and groups for the m(ttbar) analysis.
+"""
+
+import order as od
+import itertools
+
+from columnflow.util import DotDict
+
+
+def set_defaults(
+        config: od.Config,
+) -> None:
+    """
+    Set default values for the m(ttbar) analysis configuration.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    base_defaults = DotDict.wrap({
+        "calibrator": "skip_jecunc",
+        "selector": "default",
+        "reducer": "default",
+        "producer": None,
+        "weight_producer": "all_weights",
+        "hist_producer": "cf_default",
+        "ml_model": None,
+        "inference_model": "simple",
+        "categories": [
+            "1m", "1e", "1m__0t", "1e__0t", "1m__1t", "1e__1t"
+        ],
+        "variables": [
+            "electron_pt", "muon_pt"
+        ],
+        "dataset": "tt_sl_powheg",
+    })
+
+    overrides = {
+        # set custum defaults for specific runs and tags if needed
+        # (3, "2022preEE"): DotDict.wrap({
+        #     "reducer": "cf_default",
+        # })
+    }
+
+    override = overrides.get((run, tag), DotDict())
+    merged_defaults = {**base_defaults, **override}
+
+    for key, value in merged_defaults.items():
+        setattr(config.x, f"default_{key}", value)
+
+
+def set_process_groups(
+        config: od.Config,
+) -> None:
+    """
+    Set groups for the m(ttbar) analysis configuration.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    base_processes = DotDict.wrap({
+        "bkg": [
+            "tt",
+            "st",
+            "w_lnu",
+            "dy",
+            "qcd",
+            "vv",
+        ],
+        "sig": [
+            "zprime_tt_m500_w50",
+        ],
+    })
+
+    base_processes.default = base_processes.bkg + base_processes.sig
+    overrides = {
+        # set custom process groups for specific runs and tags if needed
+        (3, "2022preEE"): DotDict.wrap({
+            "sig": [],
+        }),
+        (3, "2022postEE"): DotDict.wrap({
+            "sig": [],
+        }),
+    }
+    override = overrides.get((run, tag), DotDict())
+    merged_processes = {**base_processes, **override}
+
+    config.x.process_groups = DotDict.wrap(merged_processes)
+
+
+def set_dataset_groups(
+        config: od.Config,
+) -> None:
+    """
+    Set groups for the datasets in the m(ttbar) analysis configuration.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    base_datasets = DotDict.wrap({
+        "all": ["*"],
+        "data": [
+            "data_mu_*", "data_egamma_*",
+        ],
+        "tt": ["tt_*"],
+        "st": ["st_*"],
+        "w": ["w_lnu_*"],
+        "dy": ["dy_*"],
+        "w_lnu": ["w_lnu_*"],
+        "qcd": ["qcd_*"],
+        "vv": ["ww_*", "wz_*", "zz_*"],
+        "zprime_tt": ["zprime_tt_*"],
+        "hpseudo_tt": ["hpseudo_tt_*"],
+        "hscalar_tt": ["hscalar_tt_*"],
+        "rsgluon_tt": ["rsgluon_tt_*"],
+        "bkg": [
+            "tt_*", "st_*", "w_lnu_*", "dy_*",
+            "qcd_*", "ww_*", "wz_*", "zz_*",
+        ],
+        "zprime_default": [
+            "zprime_tt_m500_w50_madgraph",
+            "zprime_tt_m1000_w100_madgraph",
+            "zprime_tt_m3000_w300_madgraph",
+        ],
+    })
+
+    overrides = {
+        # set custom dataset groups for specific runs and tags if needed
+        (2, "2017"): DotDict.wrap({
+            "data": [
+                "data_mu_*", "data_e_*", "data_pho_*",
+            ],
+        }),
+    }
+    override = overrides.get((run, tag), DotDict())
+    merged_datasets = {**base_datasets, **override}
+
+    config.x.dataset_groups = DotDict.wrap(merged_datasets)
+
+
+def set_category_groups(
+        config: od.Config,
+) -> None:
+    """
+    Set groups for the categories in the m(ttbar) analysis configuration.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    lepton_categories = [
+        "1e", "1m",
+    ]
+    top_tag_categories = [
+        "0t", "1t",
+    ]
+    chi2_categories = [
+        "pass", "fail"
+    ]
+    acts_categories = [
+        "0_5", "5_7", "7_9", "9_1"
+    ]
+
+    def generate_all_category_combinations(
+            dimensions: tuple,
+            min_depth: int = 1,
+            max_depth: int = None
+    ) -> list[str]:
+        """
+        Generate all combinations of categories from the given dimensions.
+
+        Parameters:
+            dimensions: list of (label_prefix, values) tuples
+            min_depth: minimum number of dimensions to combine
+            max_depth: maximum number of dimensions to combine (default: all)
+
+        Returns:
+            Sorted list of all category combinations as strings
+        """
+        if max_depth is None:
+            max_depth = len(dimensions)
+
+        all_combinations = set()
+
+        for depth in range(min_depth, max_depth + 1):
+            for dim_subset in itertools.combinations(dimensions, depth):
+                labels, values_lists = zip(*dim_subset)
+                for values in itertools.product(*values_lists):
+                    parts = [
+                        f"{label}{value}" if label else value
+                        for label, value in zip(labels, values)
+                    ]
+                    all_combinations.add("__".join(parts))
+
+        return sorted(all_combinations)
+
+    dims = [
+        ("", lepton_categories),
+        ("", top_tag_categories),
+        ("chi2", chi2_categories),
+        ("acts_", acts_categories),
+    ]
+    all_categories = generate_all_category_combinations(dims, min_depth=1)
+
+    base_categories = DotDict.wrap({
+        "default": config.x.default_categories,
+        "all": all_categories + ["incl"],  # careful, lots of categories
+        "lepton": lepton_categories,
+        "chi2p": [
+            f"{lep}__{toptag}__chi2pass"
+            for lep in lepton_categories
+            for toptag in top_tag_categories
+        ],
+        "chi2f": [
+            f"{lep}__{toptag}__chi2fail"
+            for lep in lepton_categories
+            for toptag in top_tag_categories
+        ],
+        "resolved": [
+            f"{lep}__0t__chi2{chi2}__acts_{acts}"
+            for lep in lepton_categories
+            for chi2 in chi2_categories
+            for acts in acts_categories
+        ],
+        "boosted": [
+            f"{lep}__1t__chi2{chi2}__acts_{acts}"
+            for lep in lepton_categories
+            for chi2 in chi2_categories
+            for acts in acts_categories
+        ],
+    })
+
+    overrides = {
+        # set custom category groups for specific runs and tags if needed
+    }
+    override = overrides.get((run, tag), DotDict())
+    merged_categories = {**base_categories, **override}
+
+    config.x.category_groups = DotDict.wrap(merged_categories)
+
+
+def set_variables_groups(
+        config: od.Config,
+) -> None:
+    """
+    Set groups for the variables in the m(ttbar) analysis configuration.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    base_variables = DotDict.wrap({
+        "default": [
+            "n_jet", "n_muon", "n_electron",
+            "jet1_pt", "jet2_pt", "jet3_pt", "jet4_pt",
+            "fatjet1_pt", "fatjet2_pt", "fatjet3_pt", "fatjet4_pt",
+            "muon_pt", "muon_eta",
+            "electron_pt", "electron_eta",
+        ],
+        "cutflow": [
+            "cf_n_jet", "cf_n_muon", "cf_n_electron",
+            "cf_jet1_pt", "cf_jet2_pt", "cf_jet3_pt", "cf_jet4_pt",
+            "cf_fatjet1_pt", "cf_fatjet2_pt", "cf_fatjet3_pt", "cf_fatjet4_pt",
+            "cf_muon_pt", "cf_muon_eta",
+            "cf_electron_pt", "cf_electron_eta",
+        ],
+        "new_version_test": [
+            "n_jet", "n_electron", "n_muon",
+            "met_pt", "met_phi",
+            "electron_pt", "electron_phi",
+            "muon_pt", "muon_phi",
+            "jet1_pt", "jet1_phi",
+            "fatjet1_pt", "fatjet1_phi",
+            "chi2_lt100",
+            "top_had_mass",
+            "top_lep_mass",
+            "cos_theta_star",
+            # "gen_top_had_mass",
+            # "gen_top_lep_mass",
+            # "gen_cos_theta_star",
+        ],
+    })
+
+    overrides = {
+        # set custom variable groups for specific runs and tags if needed
+    }
+    override = overrides.get((run, tag), DotDict())
+    merged_variables = {**base_variables, **override}
+
+    config.x.variable_groups = DotDict.wrap(merged_variables)
+
+
+def set_shift_groups(
+        config: od.Config,
+) -> None:
+    """
+    Set groups for the shifts in the m(ttbar) analysis configuration.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    base_shifts = DotDict.wrap({
+        "jer": ["nominal", "jer_up", "jer_down"],
+    })
+
+    overrides = {
+        # set custom shift groups for specific runs and tags if needed
+    }
+    override = overrides.get((run, tag), DotDict())
+    merged_shifts = {**base_shifts, **override}
+
+    config.x.shift_groups = DotDict.wrap(merged_shifts)
+
+
+def set_selector_steps(
+        config: od.Config,
+) -> None:
+    """
+    Set selector steps for the m(ttbar) analysis configuration.
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    base_steps = DotDict.wrap({
+        "default": ["Lepton", "MET", "Jet", "BJet", "JetLepton2DCut", "AllHadronicVeto", "DileptonVeto", "METFilters"],
+    })
+    base_steps_labels = DotDict.wrap({
+        "JetLepton2DCut": "2D cut",
+        "AllHadronicVeto": r"all-hadr. veto",
+        "DileptonVeto": r"dilep. veto",
+    })
+
+    overrides = {
+        # set custom selector steps for specific runs and tags if needed
+    }
+    overrides_labels = {
+        # set custom labels for specific selector steps for specific runs and tags if needed
+    }
+    override = overrides.get((run, tag), DotDict())
+    override_labels = overrides_labels.get((run, tag), DotDict())
+    merged_steps = {**base_steps, **override}
+    merged_steps_labels = {**base_steps_labels, **override_labels}
+
+    config.x.selector_steps = DotDict.wrap(merged_steps)
+    config.x.selector_steps_labels = DotDict.wrap(merged_steps_labels)

--- a/mtt/config/defaults_and_groups.py
+++ b/mtt/config/defaults_and_groups.py
@@ -266,11 +266,11 @@ def set_variables_groups(
         ],
         "new_version_test": [
             "n_jet", "n_electron", "n_muon",
-            "met_pt", "met_phi",
-            "electron_pt", "electron_phi",
-            "muon_pt", "muon_phi",
-            "jet1_pt", "jet1_phi",
-            "fatjet1_pt", "fatjet1_phi",
+            "puppi_met_pt", "puppi_met_phi",
+            "electron_pt", "electron_phi", "electron_eta",
+            "muon_pt", "muon_phi", "muon_eta",
+            "jet1_pt", "jet1_phi", "jet1_eta",
+            "fatjet1_pt", "fatjet1_phi", "fatjet1_eta",
             "chi2_lt100",
             "top_had_mass",
             "top_lep_mass",
@@ -321,14 +321,15 @@ def set_selector_steps(
     run = config.campaign.x.run
     tag = config.x.cpn_tag
 
-    base_steps = DotDict.wrap({
-        "default": ["Lepton", "MET", "Jet", "BJet", "JetLepton2DCut", "AllHadronicVeto", "DileptonVeto", "METFilters"],
-    })
-    base_steps_labels = DotDict.wrap({
+    base_steps = {
+        "default": ["METFilters", "DiLeptonVeto", "AllHadronicVeto", "JetLepton2DCut", "BJet", "Jet", "MET", "Lepton"],
+    }
+    base_steps_labels = {
         "JetLepton2DCut": "2D cut",
         "AllHadronicVeto": r"all-hadr. veto",
         "DileptonVeto": r"dilep. veto",
-    })
+        "jet_veto_map": "JetVetoMap",
+    }
 
     overrides = {
         # set custom selector steps for specific runs and tags if needed
@@ -341,5 +342,5 @@ def set_selector_steps(
     merged_steps = {**base_steps, **override}
     merged_steps_labels = {**base_steps_labels, **override_labels}
 
-    config.x.selector_steps = DotDict.wrap(merged_steps)
+    config.x.selector_step_groups = DotDict.wrap(merged_steps)
     config.x.selector_steps_labels = DotDict.wrap(merged_steps_labels)

--- a/mtt/config/run3/analysis_mtt.py
+++ b/mtt/config/run3/analysis_mtt.py
@@ -62,219 +62,186 @@ ana.x.config_groups = {}
 
 #
 # set up configs
+# ONLY 2024 CONFIGS WORKING FOR NOW
 #
 
-from mtt.config.run3.config_mtt import add_config
+# from mtt.config.run3.config_mtt import add_config
 from mtt.config.run3.new_mtt_config import add_new_config
 
-from cmsdb.campaigns.run3_2022_preEE_nano_v12 import campaign_run3_2022_preEE_nano_v12 as campaign_run3_2022_preEE_nano_v12  # noqa
-from cmsdb.campaigns.run3_2022_postEE_nano_v12 import campaign_run3_2022_postEE_nano_v12 as campaign_run3_2022_postEE_nano_v12  # noqa
-from cmsdb.campaigns.run3_2023_preBPix_nano_v12 import campaign_run3_2023_preBPix_nano_v12 as campaign_run3_2023_preBPix_nano_v12  # noqa
-from cmsdb.campaigns.run3_2023_postBPix_nano_v12 import campaign_run3_2023_postBPix_nano_v12 as campaign_run3_2023_postBPix_nano_v12  # noqa
+# from cmsdb.campaigns.run3_2022_preEE_nano_v12 import campaign_run3_2022_preEE_nano_v12 as campaign_run3_2022_preEE_nano_v12  # noqa
+# from cmsdb.campaigns.run3_2022_postEE_nano_v12 import campaign_run3_2022_postEE_nano_v12 as campaign_run3_2022_postEE_nano_v12  # noqa
+# from cmsdb.campaigns.run3_2023_preBPix_nano_v12 import campaign_run3_2023_preBPix_nano_v12 as campaign_run3_2023_preBPix_nano_v12  # noqa
+# from cmsdb.campaigns.run3_2023_postBPix_nano_v12 import campaign_run3_2023_postBPix_nano_v12 as campaign_run3_2023_postBPix_nano_v12  # noqa
 from cmsdb.campaigns.run3_2024_nano_v15 import campaign_run3_2024_nano_v15 as campaign_run3_2024_nano_v15  # noqa
 
-campaign_run3_2022_preEE_nano_v12.x.EE = "pre"
-campaign_run3_2022_postEE_nano_v12.x.EE = "post"
-campaign_run3_2023_preBPix_nano_v12.x.BPix = "pre"
-campaign_run3_2023_postBPix_nano_v12.x.BPix = "post"
+# campaign_run3_2022_preEE_nano_v12.x.EE = "pre"
+# campaign_run3_2022_postEE_nano_v12.x.EE = "post"
+# campaign_run3_2023_preBPix_nano_v12.x.BPix = "pre"
+# campaign_run3_2023_postBPix_nano_v12.x.BPix = "post"
 
-#
-# 22preEE
-# id: 3_22_x1 with x in
-# (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
-# with old/new configs
-#
+# #
+# # 22preEE
+# # id: 3_22_x1 with x in
+# # (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
+# # with old/new configs
+# #
 
-# configs with full statistics
-config_2022_preEE = add_config(
-    ana,
-    campaign_run3_2022_preEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_preEE_nano_v12",
-    config_id=3_22_11,  # 3: Run3 22: year 1: full stat 1: pre EE
-)
-config_2022_preEE_new = add_new_config(
-    ana_new,
-    campaign_run3_2022_preEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_preEE_nano_v12_new",
-    config_id=3_22_91,  # 3: Run3 22: year 9: full stat, new config 1: pre EE
-)
+# # configs with full statistics
+# config_2022_preEE = add_config(
+#     ana,
+#     campaign_run3_2022_preEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_preEE_nano_v12",
+#     config_id=3_22_11,  # 3: Run3 22: year 1: full stat 1: pre EE
+# )
+# config_2022_preEE_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2022_preEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_preEE_nano_v12_new",
+#     config_id=3_22_91,  # 3: Run3 22: year 9: full stat, new config 1: pre EE
+# )
 
-# configs with limited number of files
-config_2022_preEE_limited = add_config(
-    ana,
-    campaign_run3_2022_preEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_preEE_nano_v12_limited",
-    config_id=3_22_21,  # 3: Run3 22: year 2: limited stat 1: pre EE
-    limit_dataset_files=2,
-)
+# # configs with limited number of files
+# config_2022_preEE_limited = add_config(
+#     ana,
+#     campaign_run3_2022_preEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_preEE_nano_v12_limited",
+#     config_id=3_22_21,  # 3: Run3 22: year 2: limited stat 1: pre EE
+#     limit_dataset_files=2,
+# )
 
-config_2022_preEE_limited_new = add_new_config(
-    ana_new,
-    campaign_run3_2022_preEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_preEE_nano_v12_limited_new",
-    config_id=3_22_81,  # 3: Run3 22: year 8: limited stat, new config 1: pre EE
-    limit_dataset_files=2,
-)
+# config_2022_preEE_limited_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2022_preEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_preEE_nano_v12_limited_new",
+#     config_id=3_22_81,  # 3: Run3 22: year 8: limited stat, new config 1: pre EE
+#     limit_dataset_files=2,
+# )
 
-# configs with medium limited number of files
-config_2022_preEE_medium_limited = add_config(
-    ana,
-    campaign_run3_2022_preEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_preEE_nano_v12_medium_limited",
-    config_id=3_22_31,  # 3: Run3 22: year 3: medium limited stat 1: pre EE
-    limit_dataset_files=10,
-)
+# # configs with medium limited number of files
+# config_2022_preEE_medium_limited = add_config(
+#     ana,
+#     campaign_run3_2022_preEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_preEE_nano_v12_medium_limited",
+#     config_id=3_22_31,  # 3: Run3 22: year 3: medium limited stat 1: pre EE
+#     limit_dataset_files=10,
+# )
 
-config_2022_preEE_medium_limited_new = add_new_config(
-    ana_new,
-    campaign_run3_2022_preEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_preEE_nano_v12_medium_limited_new",
-    config_id=3_22_71,  # 3: Run3 22: year 7: medium limited stat, new config 2: post EE
-    limit_dataset_files=10,
-)
+# config_2022_preEE_medium_limited_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2022_preEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_preEE_nano_v12_medium_limited_new",
+#     config_id=3_22_71,  # 3: Run3 22: year 7: medium limited stat, new config 2: post EE
+#     limit_dataset_files=10,
+# )
 
-#
-# 22postEE
-# id: 3_22_x2 with x in
-# (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
-# with old/new configs
-#
+# #
+# # 22postEE
+# # id: 3_22_x2 with x in
+# # (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
+# # with old/new configs
+# #
 
-# configs with full statistics
-config_2022_postEE = add_config(
-    ana,
-    campaign_run3_2022_postEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_postEE_nano_v12",
-    config_id=3_22_12,  # 3: Run3 22: year 1: full stat 2: post EE
-)
-config_2022_postEE_new = add_new_config(
-    ana_new,
-    campaign_run3_2022_postEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_postEE_nano_v12_new",
-    config_id=3_22_92,  # 3: Run3 22: year 9: full stat, new config 2: post EE
-)
+# # configs with full statistics
+# config_2022_postEE = add_config(
+#     ana,
+#     campaign_run3_2022_postEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_postEE_nano_v12",
+#     config_id=3_22_12,  # 3: Run3 22: year 1: full stat 2: post EE
+# )
+# config_2022_postEE_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2022_postEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_postEE_nano_v12_new",
+#     config_id=3_22_92,  # 3: Run3 22: year 9: full stat, new config 2: post EE
+# )
 
-# configs with limited number of files
-config_2022_postEE_limited = add_config(
-    ana,
-    campaign_run3_2022_postEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_postEE_nano_v12_limited",
-    config_id=3_22_22,  # 3: Run3 22: year 2: limited stat 2: post EE
-    limit_dataset_files=2,
-)
-config_2022_postEE_limited_new = add_new_config(
-    ana_new,
-    campaign_run3_2022_postEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_postEE_nano_v12_limited_new",
-    config_id=3_22_82,  # 3: Run3 22: year 2: limited stat, new config 2: post EE
-    limit_dataset_files=2,
-)
+# # configs with limited number of files
+# config_2022_postEE_limited = add_config(
+#     ana,
+#     campaign_run3_2022_postEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_postEE_nano_v12_limited",
+#     config_id=3_22_22,  # 3: Run3 22: year 2: limited stat 2: post EE
+#     limit_dataset_files=2,
+# )
+# config_2022_postEE_limited_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2022_postEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_postEE_nano_v12_limited_new",
+#     config_id=3_22_82,  # 3: Run3 22: year 2: limited stat, new config 2: post EE
+#     limit_dataset_files=2,
+# )
 
-# configs with medium limited number of files
-config_2022_postEE_medium_limited = add_config(
-    ana,
-    campaign_run3_2022_postEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_postEE_nano_v12_medium_limited",
-    config_id=3_22_32,  # 3: Run3 22: year 3: medium limited stat 2: post EE
-    limit_dataset_files=10,
-)
-config_2022_postEE_medium_limited_new = add_new_config(
-    ana_new,
-    campaign_run3_2022_postEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_postEE_nano_v12_medium_limited_new",
-    config_id=3_22_72,  # 3: Run3 22: year 3: medium limited stat, new config 2: post EE
-    limit_dataset_files=10,
-)
+# # configs with medium limited number of files
+# config_2022_postEE_medium_limited = add_config(
+#     ana,
+#     campaign_run3_2022_postEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_postEE_nano_v12_medium_limited",
+#     config_id=3_22_32,  # 3: Run3 22: year 3: medium limited stat 2: post EE
+#     limit_dataset_files=10,
+# )
+# config_2022_postEE_medium_limited_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2022_postEE_nano_v12.copy(),
+#     config_name="run3_mtt_2022_postEE_nano_v12_medium_limited_new",
+#     config_id=3_22_72,  # 3: Run3 22: year 3: medium limited stat, new config 2: post EE
+#     limit_dataset_files=10,
+# )
 
-#
-# 23prePBix
-# id: 3_23_x1 with x in
-# (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
-# with old/new configs
-#
+# #
+# # 23prePBix
+# # id: 3_23_x1 with x in
+# # (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
+# # with old/new configs
+# #
 
-# configs with full statistics
-config_2023_preBPix_new = add_new_config(
-    ana_new,
-    campaign_run3_2023_preBPix_nano_v12.copy(),
-    config_name="run3_mtt_2023_preBPix_nano_v12_new",
-    config_id=3_23_91,  # 3: Run3 23: year 9: full stat, new config 1: pre BPix
-)
+# # configs with full statistics
+# config_2023_preBPix_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2023_preBPix_nano_v12.copy(),
+#     config_name="run3_mtt_2023_preBPix_nano_v12_new",
+#     config_id=3_23_91,  # 3: Run3 23: year 9: full stat, new config 1: pre BPix
+# )
 
-config_2023_postBPix_new = add_new_config(
-    ana_new,
-    campaign_run3_2023_postBPix_nano_v12.copy(),
-    config_name="run3_mtt_2023_postBPix_nano_v12_new",
-    config_id=3_23_92,  # 3: Run3 23: year 9: full stat, new config 2: post BPix
-)
+# config_2023_postBPix_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2023_postBPix_nano_v12.copy(),
+#     config_name="run3_mtt_2023_postBPix_nano_v12_new",
+#     config_id=3_23_92,  # 3: Run3 23: year 9: full stat, new config 2: post BPix
+# )
 
-# configs with limited number of files
-config_2023_preBPix_limited_new = add_new_config(
-    ana_new,
-    campaign_run3_2023_preBPix_nano_v12.copy(),
-    config_name="run3_mtt_2023_preBPix_nano_v12_limited_new",
-    config_id=3_23_81,  # 3: Run3 23: year 8: limited stat, new config 1: pre BPix
-    limit_dataset_files=2,
-)
+# # configs with limited number of files
+# config_2023_preBPix_limited_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2023_preBPix_nano_v12.copy(),
+#     config_name="run3_mtt_2023_preBPix_nano_v12_limited_new",
+#     config_id=3_23_81,  # 3: Run3 23: year 8: limited stat, new config 1: pre BPix
+#     limit_dataset_files=2,
+# )
 
-config_2023_postBPix_limited_new = add_new_config(
-    ana_new,
-    campaign_run3_2023_postBPix_nano_v12.copy(),
-    config_name="run3_mtt_2023_postBPix_nano_v12_limited_new",
-    config_id=3_23_82,  # 3: Run3 23: year 8: limited stat, new config 2: post BPix
-    limit_dataset_files=2,
-)
+# config_2023_postBPix_limited_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2023_postBPix_nano_v12.copy(),
+#     config_name="run3_mtt_2023_postBPix_nano_v12_limited_new",
+#     config_id=3_23_82,  # 3: Run3 23: year 8: limited stat, new config 2: post BPix
+#     limit_dataset_files=2,
+# )
 
-# configs with medium limited number of files
-config_2023_preBPix_medium_limited_new = add_new_config(
-    ana_new,
-    campaign_run3_2023_preBPix_nano_v12.copy(),
-    config_name="run3_mtt_2023_preBPix_nano_v12_medium_limited_new",
-    config_id=3_23_71,  # 3: Run3 23: year 7: medium limited stat, new config 1: pre BPix
-    limit_dataset_files=10,
-)
+# # configs with medium limited number of files
+# config_2023_preBPix_medium_limited_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2023_preBPix_nano_v12.copy(),
+#     config_name="run3_mtt_2023_preBPix_nano_v12_medium_limited_new",
+#     config_id=3_23_71,  # 3: Run3 23: year 7: medium limited stat, new config 1: pre BPix
+#     limit_dataset_files=10,
+# )
 
-config_2023_postBPix_medium_limited_new = add_new_config(
-    ana_new,
-    campaign_run3_2023_postBPix_nano_v12.copy(),
-    config_name="run3_mtt_2023_postBPix_nano_v12_medium_limited_new",
-    config_id=3_23_72,  # 3: Run3 23: year 7: medium limited stat, new config 2: post BPix
-    limit_dataset_files=10,
-)
-
-#
-# 24
-# id: 3_24_x1 with x in
-# (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
-# with old/new configs
-#
-
-# configs with full statistics
-config_2024_new = add_new_config(
-    ana_new,
-    campaign_run3_2024_nano_v15.copy(),
-    config_name="run3_mtt_2024_nano_v15_new",
-    config_id=3_24_11,  # 3: Run3 24: year 1: full stat 1: 24
-)
-
-# configs with limited number of files
-config_2024_limited_new = add_new_config(
-    ana_new,
-    campaign_run3_2024_nano_v15.copy(),
-    config_name="run3_mtt_2024_nano_v15_limited_new",
-    config_id=3_24_21,  # 3: Run3 24
-    limit_dataset_files=2,
-)
-
-# configs with medium limited number of files
-config_2024_medium_limited_new = add_new_config(
-    ana_new,
-    campaign_run3_2024_nano_v15.copy(),
-    config_name="run3_mtt_2024_nano_v15_medium_limited_new",
-    config_id=3_24_31,  # 3: Run3 24
-    limit_dataset_files=10,
-)
-
+# config_2023_postBPix_medium_limited_new = add_new_config(
+#     ana_new,
+#     campaign_run3_2023_postBPix_nano_v12.copy(),
+#     config_name="run3_mtt_2023_postBPix_nano_v12_medium_limited_new",
+#     config_id=3_23_72,  # 3: Run3 23: year 7: medium limited stat, new config 2: post BPix
+#     limit_dataset_files=10,
+# )
 
 # config_2023_preBPix = add_config(
 #     ana,
@@ -307,3 +274,37 @@ config_2024_medium_limited_new = add_new_config(
 #     config_id=3_23_22,  # 3: Run3 23: year 2: limited stat 2: post BPix
 #     limit_dataset_files=1,
 # )
+
+#
+# 24
+# id: 3_24_x1 with x in
+# (1: full stats, 2: limited stats, 3: medium limited stats)
+# with new config
+#
+
+# configs with full statistics
+config_2024_new = add_new_config(
+    ana_new,
+    campaign_run3_2024_nano_v15.copy(),
+    config_name="run3_mtt_2024_nano_v15_new",
+    config_id=3_24_11,  # 3: Run3 24: year 1: full stat 1: 24
+)
+
+# configs with limited number of files
+config_2024_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2024_nano_v15.copy(),
+    config_name="run3_mtt_2024_nano_v15_limited_new",
+    config_id=3_24_21,  # 3: Run3 24
+    limit_dataset_files=2,
+)
+
+# configs with medium limited number of files
+config_2024_medium_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2024_nano_v15.copy(),
+    config_name="run3_mtt_2024_nano_v15_medium_limited_new",
+    config_id=3_24_31,  # 3: Run3 24
+    limit_dataset_files=10,
+)
+

--- a/mtt/config/run3/analysis_mtt.py
+++ b/mtt/config/run3/analysis_mtt.py
@@ -21,6 +21,11 @@ analysis_mtt = ana = od.Analysis(
     id=1,
 )
 
+analysis_mtt_new = ana_new = od.Analysis(
+    name="new_analysis_mtt",
+    id=2,
+)
+
 # analysis-global versions
 ana.x.versions = {}
 
@@ -32,9 +37,18 @@ ana.x.bash_sandboxes = [
     # "$MTT_BASE/sandboxes/venv_columnar_tf.sh",
     "$CF_BASE/sandboxes/venv_ml_tf.sh",
 ]
+ana_new.x.bash_sandboxes = [
+    "$CF_BASE/sandboxes/cf.sh",
+    "$CF_BASE/sandboxes/venv_columnar.sh",
+    # "$MTT_BASE/sandboxes/venv_columnar_tf.sh",
+    "$CF_BASE/sandboxes/venv_ml_tf.sh",
+]
 
 # cmssw sandboxes that should be bundled for remote jobs in case they are needed
 ana.x.cmssw_sandboxes = [
+    # "$CF_BASE/sandboxes/cmssw_default.sh",
+]
+ana_new.x.cmssw_sandboxes = [
     # "$CF_BASE/sandboxes/cmssw_default.sh",
 ]
 
@@ -51,31 +65,216 @@ ana.x.config_groups = {}
 #
 
 from mtt.config.run3.config_mtt import add_config
+from mtt.config.run3.new_mtt_config import add_new_config
 
 from cmsdb.campaigns.run3_2022_preEE_nano_v12 import campaign_run3_2022_preEE_nano_v12 as campaign_run3_2022_preEE_nano_v12  # noqa
 from cmsdb.campaigns.run3_2022_postEE_nano_v12 import campaign_run3_2022_postEE_nano_v12 as campaign_run3_2022_postEE_nano_v12  # noqa
-# from cmsdb.campaigns.run3_2023_preBPix_nano_v12 import campaign_run3_2023_preBPix_nano_v12 as campaign_run3_2023_preBPix_nano_v12  # noqa
-# from cmsdb.campaigns.run3_2023_postBPix_nano_v12 import campaign_run3_2023_postBPix_nano_v12 as campaign_run3_2023_postBPix_nano_v12  # noqa
+from cmsdb.campaigns.run3_2023_preBPix_nano_v12 import campaign_run3_2023_preBPix_nano_v12 as campaign_run3_2023_preBPix_nano_v12  # noqa
+from cmsdb.campaigns.run3_2023_postBPix_nano_v12 import campaign_run3_2023_postBPix_nano_v12 as campaign_run3_2023_postBPix_nano_v12  # noqa
+from cmsdb.campaigns.run3_2024_nano_v15 import campaign_run3_2024_nano_v15 as campaign_run3_2024_nano_v15  # noqa
 
 campaign_run3_2022_preEE_nano_v12.x.EE = "pre"
 campaign_run3_2022_postEE_nano_v12.x.EE = "post"
-# campaign_run3_2023_preBPix_nano_v12.x.BPix = "pre"
-# campaign_run3_2023_postBPix_nano_v12.x.BPix = "post"
+campaign_run3_2023_preBPix_nano_v12.x.BPix = "pre"
+campaign_run3_2023_postBPix_nano_v12.x.BPix = "post"
 
-# default config
+#
+# 22preEE
+# id: 3_22_x1 with x in
+# (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
+# with old/new configs
+#
+
+# configs with full statistics
 config_2022_preEE = add_config(
     ana,
     campaign_run3_2022_preEE_nano_v12.copy(),
     config_name="run3_mtt_2022_preEE_nano_v12",
     config_id=3_22_11,  # 3: Run3 22: year 1: full stat 1: pre EE
 )
+config_2022_preEE_new = add_new_config(
+    ana_new,
+    campaign_run3_2022_preEE_nano_v12.copy(),
+    config_name="run3_mtt_2022_preEE_nano_v12_new",
+    config_id=3_22_91,  # 3: Run3 22: year 9: full stat, new config 1: pre EE
+)
 
+# configs with limited number of files
+config_2022_preEE_limited = add_config(
+    ana,
+    campaign_run3_2022_preEE_nano_v12.copy(),
+    config_name="run3_mtt_2022_preEE_nano_v12_limited",
+    config_id=3_22_21,  # 3: Run3 22: year 2: limited stat 1: pre EE
+    limit_dataset_files=2,
+)
+
+config_2022_preEE_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2022_preEE_nano_v12.copy(),
+    config_name="run3_mtt_2022_preEE_nano_v12_limited_new",
+    config_id=3_22_81,  # 3: Run3 22: year 8: limited stat, new config 1: pre EE
+    limit_dataset_files=2,
+)
+
+# configs with medium limited number of files
+config_2022_preEE_medium_limited = add_config(
+    ana,
+    campaign_run3_2022_preEE_nano_v12.copy(),
+    config_name="run3_mtt_2022_preEE_nano_v12_medium_limited",
+    config_id=3_22_31,  # 3: Run3 22: year 3: medium limited stat 1: pre EE
+    limit_dataset_files=10,
+)
+
+config_2022_preEE_medium_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2022_preEE_nano_v12.copy(),
+    config_name="run3_mtt_2022_preEE_nano_v12_medium_limited_new",
+    config_id=3_22_71,  # 3: Run3 22: year 7: medium limited stat, new config 2: post EE
+    limit_dataset_files=10,
+)
+
+#
+# 22postEE
+# id: 3_22_x2 with x in
+# (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
+# with old/new configs
+#
+
+# configs with full statistics
 config_2022_postEE = add_config(
     ana,
     campaign_run3_2022_postEE_nano_v12.copy(),
     config_name="run3_mtt_2022_postEE_nano_v12",
     config_id=3_22_12,  # 3: Run3 22: year 1: full stat 2: post EE
 )
+config_2022_postEE_new = add_new_config(
+    ana_new,
+    campaign_run3_2022_postEE_nano_v12.copy(),
+    config_name="run3_mtt_2022_postEE_nano_v12_new",
+    config_id=3_22_92,  # 3: Run3 22: year 9: full stat, new config 2: post EE
+)
+
+# configs with limited number of files
+config_2022_postEE_limited = add_config(
+    ana,
+    campaign_run3_2022_postEE_nano_v12.copy(),
+    config_name="run3_mtt_2022_postEE_nano_v12_limited",
+    config_id=3_22_22,  # 3: Run3 22: year 2: limited stat 2: post EE
+    limit_dataset_files=2,
+)
+config_2022_postEE_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2022_postEE_nano_v12.copy(),
+    config_name="run3_mtt_2022_postEE_nano_v12_limited_new",
+    config_id=3_22_82,  # 3: Run3 22: year 2: limited stat, new config 2: post EE
+    limit_dataset_files=2,
+)
+
+# configs with medium limited number of files
+config_2022_postEE_medium_limited = add_config(
+    ana,
+    campaign_run3_2022_postEE_nano_v12.copy(),
+    config_name="run3_mtt_2022_postEE_nano_v12_medium_limited",
+    config_id=3_22_32,  # 3: Run3 22: year 3: medium limited stat 2: post EE
+    limit_dataset_files=10,
+)
+config_2022_postEE_medium_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2022_postEE_nano_v12.copy(),
+    config_name="run3_mtt_2022_postEE_nano_v12_medium_limited_new",
+    config_id=3_22_72,  # 3: Run3 22: year 3: medium limited stat, new config 2: post EE
+    limit_dataset_files=10,
+)
+
+#
+# 23prePBix
+# id: 3_23_x1 with x in
+# (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
+# with old/new configs
+#
+
+# configs with full statistics
+config_2023_preBPix_new = add_new_config(
+    ana_new,
+    campaign_run3_2023_preBPix_nano_v12.copy(),
+    config_name="run3_mtt_2023_preBPix_nano_v12_new",
+    config_id=3_23_91,  # 3: Run3 23: year 9: full stat, new config 1: pre BPix
+)
+
+config_2023_postBPix_new = add_new_config(
+    ana_new,
+    campaign_run3_2023_postBPix_nano_v12.copy(),
+    config_name="run3_mtt_2023_postBPix_nano_v12_new",
+    config_id=3_23_92,  # 3: Run3 23: year 9: full stat, new config 2: post BPix
+)
+
+# configs with limited number of files
+config_2023_preBPix_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2023_preBPix_nano_v12.copy(),
+    config_name="run3_mtt_2023_preBPix_nano_v12_limited_new",
+    config_id=3_23_81,  # 3: Run3 23: year 8: limited stat, new config 1: pre BPix
+    limit_dataset_files=2,
+)
+
+config_2023_postBPix_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2023_postBPix_nano_v12.copy(),
+    config_name="run3_mtt_2023_postBPix_nano_v12_limited_new",
+    config_id=3_23_82,  # 3: Run3 23: year 8: limited stat, new config 2: post BPix
+    limit_dataset_files=2,
+)
+
+# configs with medium limited number of files
+config_2023_preBPix_medium_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2023_preBPix_nano_v12.copy(),
+    config_name="run3_mtt_2023_preBPix_nano_v12_medium_limited_new",
+    config_id=3_23_71,  # 3: Run3 23: year 7: medium limited stat, new config 1: pre BPix
+    limit_dataset_files=10,
+)
+
+config_2023_postBPix_medium_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2023_postBPix_nano_v12.copy(),
+    config_name="run3_mtt_2023_postBPix_nano_v12_medium_limited_new",
+    config_id=3_23_72,  # 3: Run3 23: year 7: medium limited stat, new config 2: post BPix
+    limit_dataset_files=10,
+)
+
+#
+# 24
+# id: 3_24_x1 with x in
+# (1/9: full stats, 2/8: limited stats, 3/7: medium limited stats)
+# with old/new configs
+#
+
+# configs with full statistics
+config_2024_new = add_new_config(
+    ana_new,
+    campaign_run3_2024_nano_v15.copy(),
+    config_name="run3_mtt_2024_nano_v15_new",
+    config_id=3_24_11,  # 3: Run3 24: year 1: full stat 1: 24
+)
+
+# configs with limited number of files
+config_2024_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2024_nano_v15.copy(),
+    config_name="run3_mtt_2024_nano_v15_limited_new",
+    config_id=3_24_21,  # 3: Run3 24
+    limit_dataset_files=2,
+)
+
+# configs with medium limited number of files
+config_2024_medium_limited_new = add_new_config(
+    ana_new,
+    campaign_run3_2024_nano_v15.copy(),
+    config_name="run3_mtt_2024_nano_v15_medium_limited_new",
+    config_id=3_24_31,  # 3: Run3 24
+    limit_dataset_files=10,
+)
+
 
 # config_2023_preBPix = add_config(
 #     ana,
@@ -91,40 +290,8 @@ config_2022_postEE = add_config(
 #     config_id=3_23_12,  # 3: Run3 23: year 1: full stat 2: post BPix
 # )
 
-# config with limited number of files
-config_2022_preEE_limited = add_config(
-    ana,
-    campaign_run3_2022_preEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_preEE_nano_v12_limited",
-    config_id=3_22_21,  # 3: Run3 22: year 2: limited stat 1: pre EE
-    limit_dataset_files=2,
-)
 
-config_2022_postEE_limited = add_config(
-    ana,
-    campaign_run3_2022_postEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_postEE_nano_v12_limited",
-    config_id=3_22_22,  # 3: Run3 22: year 2: limited stat 2: post EE
-    limit_dataset_files=2,
-)
-
-# config with medium limited number of files
-config_2022_preEE_medium_limited = add_config(
-    ana,
-    campaign_run3_2022_preEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_preEE_nano_v12_medium_limited",
-    config_id=3_22_31,  # 3: Run3 22: year 3: medium limited stat 1: pre EE
-    limit_dataset_files=10,
-)
-
-config_2022_postEE_medium_limited = add_config(
-    ana,
-    campaign_run3_2022_postEE_nano_v12.copy(),
-    config_name="run3_mtt_2022_postEE_nano_v12_medium_limited",
-    config_id=3_22_32,  # 3: Run3 22: year 3: medium limited stat 2: post EE
-    limit_dataset_files=10,
-)
-
+# # configs with limited number of files
 # config_2023_preBPix_limited = add_config(
 #     ana,
 #     campaign_run3_2023_preBPix_nano_v12.copy(),

--- a/mtt/config/run3/config_mtt.py
+++ b/mtt/config/run3/config_mtt.py
@@ -131,25 +131,25 @@ def add_config(
     # add datasets we need to study
     # errors taken over from top sf analysis, might work in this analysis
     dataset_names = [
-        # DY 2022 v12 preEE datasets
-        "dy_m4to50_ht40to70_madgraph",  # FIXME AssertionError in preEE (full stat.)
-        "dy_m4to50_ht70to100_madgraph",  # FIXME AssertionError in preEE (full stat.)
-        "dy_m4to50_ht100to400_madgraph",
-        "dy_m4to50_ht400to800_madgraph",
-        "dy_m4to50_ht800to1500_madgraph",
-        "dy_m4to50_ht1500to2500_madgraph",
-        "dy_m4to50_ht2500toinf_madgraph",
-        "dy_m50to120_ht40to70_madgraph",  # FIXME AssertionError in preEE (full stat.)
-        "dy_m50to120_ht70to100_madgraph",
-        "dy_m50to120_ht100to400_madgraph",
-        "dy_m50to120_ht400to800_madgraph",
-        # WJets 2022 v12 preEE datasets
-        "w_lnu_mlnu0to120_ht40to100_madgraph",
-        "w_lnu_mlnu0to120_ht100to400_madgraph",
-        "w_lnu_mlnu0to120_ht400to800_madgraph",
-        "w_lnu_mlnu0to120_ht800to1500_madgraph",
-        "w_lnu_mlnu0to120_ht1500to2500_madgraph",
-        "w_lnu_mlnu0to120_ht2500toinf_madgraph",
+        # # DY 2022 v12 preEE datasets
+        # "dy_m4to50_ht40to70_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        # "dy_m4to50_ht70to100_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        # "dy_m4to50_ht100to400_madgraph",
+        # "dy_m4to50_ht400to800_madgraph",
+        # "dy_m4to50_ht800to1500_madgraph",
+        # "dy_m4to50_ht1500to2500_madgraph",
+        # "dy_m4to50_ht2500toinf_madgraph",
+        # "dy_m50to120_ht40to70_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        # "dy_m50to120_ht70to100_madgraph",
+        # "dy_m50to120_ht100to400_madgraph",
+        # "dy_m50to120_ht400to800_madgraph",
+        # # WJets 2022 v12 preEE datasets
+        # "w_lnu_mlnu0to120_ht40to100_madgraph",
+        # "w_lnu_mlnu0to120_ht100to400_madgraph",
+        # "w_lnu_mlnu0to120_ht400to800_madgraph",
+        # "w_lnu_mlnu0to120_ht800to1500_madgraph",
+        # "w_lnu_mlnu0to120_ht1500to2500_madgraph",
+        # "w_lnu_mlnu0to120_ht2500toinf_madgraph",
         # Diboson
         "ww_pythia",
         "wz_pythia",
@@ -167,17 +167,17 @@ def add_config(
         "st_twchannel_tbar_dl_powheg",
         "st_twchannel_t_fh_powheg",
         "st_twchannel_tbar_fh_powheg",
-        # QCD 2022 v12 preEE datasets
-        "qcd_ht70to100_madgraph",  # FIXME AssertionError in preEE (full stat.)
-        "qcd_ht100to200_madgraph",  # FIXME no xs for 13.6 in https://xsdb-temp.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS%3DQCD-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8  # noqa
-        "qcd_ht200to400_madgraph",  # FIXME AssertionError in preEE (full stat.)
-        "qcd_ht400to600_madgraph",  # FIXME AssertionError in preEE (full stat.)
-        "qcd_ht600to800_madgraph",
-        "qcd_ht800to1000_madgraph",
-        "qcd_ht1000to1200_madgraph",
-        "qcd_ht1200to1500_madgraph",
-        "qcd_ht1500to2000_madgraph",
-        "qcd_ht2000toinf_madgraph",
+        # # QCD 2022 v12 preEE datasets
+        # "qcd_ht70to100_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        # "qcd_ht100to200_madgraph",  # FIXME no xs for 13.6 in https://xsdb-temp.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS%3DQCD-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8  # noqa
+        # "qcd_ht200to400_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        # "qcd_ht400to600_madgraph",  # FIXME AssertionError in preEE (full stat.)
+        # "qcd_ht600to800_madgraph",
+        # "qcd_ht800to1000_madgraph",
+        # "qcd_ht1000to1200_madgraph",
+        # "qcd_ht1200to1500_madgraph",
+        # "qcd_ht1500to2000_madgraph",
+        # "qcd_ht2000toinf_madgraph",
         # # -- signals TODO: not produced yet
         # # Z prime (width/mass = 10%)
         # "zprime_tt_m400_w40_madgraph",

--- a/mtt/config/run3/new_mtt_config.py
+++ b/mtt/config/run3/new_mtt_config.py
@@ -1,0 +1,959 @@
+# coding: utf-8
+
+"""
+Configuration for the Run 3 m(ttbar) analysis.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+
+import yaml
+from scinum import Number
+
+from columnflow.util import DotDict
+from columnflow.cms_util import CATInfo, CATSnapshot
+from columnflow.config_util import (
+    add_shift_aliases,
+    get_root_processes_from_campaign,
+    get_shifts_from_sources,
+    verify_config_processes,
+)
+from mtt.config.categories import add_categories_selection
+from mtt.config.variables import add_variables
+
+from mtt.config.datasets import (
+    data_datasets,
+    # dy_datasets,
+    # w_lnu_datasets,
+    # qcd_datasets,
+    tt_datasets,
+    st_datasets,
+    vv_datasets,
+    # Run 3 signal samples not yet in cmsdb
+    # zprime_datasets,
+    # hscalar_datasets,
+    # hpseudo_datasets,
+    # rsgluon_datasets,
+)
+from mtt.config.taggers import btag_params, toptag_params
+from mtt.config.defaults_and_groups import (
+    set_defaults,
+    set_process_groups,
+    set_dataset_groups,
+    set_category_groups,
+    set_variables_groups,
+    set_shift_groups,
+    set_selector_steps,
+)
+from mtt.config.corrections import (
+    vjets_reweighting,
+    jerc,
+    btag_sf,
+    toptag_sf,
+    lepton_sf,
+)
+
+import order as od
+
+
+thisdir = os.path.dirname(os.path.abspath(__file__))
+
+
+def add_new_config(
+    analysis: od.Analysis,
+    campaign: od.Campaign,
+    config_name: str | None = None,
+    config_id: int | None = None,
+    limit_dataset_files: int | None = None,
+) -> od.Config:
+    """
+    Configurable function for creating a config for a run3 analysis given
+    a base *analysis* object and a *campaign* (i.e. set of datasets).
+    """
+
+    # validation (TODO: why?)
+    assert campaign.x.year in [2022, 2023, 2024]
+    if campaign.x.year == 2022:
+        assert campaign.x.EE in ["pre", "post"]
+    elif campaign.x.year == 2023:
+        assert campaign.x.BPix in ["pre", "post"]
+
+    # campaign data
+    year = campaign.x.year
+    # year2 = year % 100
+    vnano = campaign.x.version
+    corr_postfix = ""
+    if year == 2022:
+        corr_postfix = f"{campaign.x.EE}EE"
+    elif year == 2023:
+        corr_postfix = f"{campaign.x.BPix}BPix"
+
+    implemented_years = [2022, 2023, 2024]
+    if year not in implemented_years:
+        raise NotImplementedError(f"Only {', '.join(map(str, implemented_years))} campaigns are implemented.")
+
+    # create a config by passing the campaign
+    # (if id and name are not set they will be taken from the campaign)
+    cfg = analysis.add_config(campaign, name=config_name, id=config_id)
+
+    # add tags to config
+    cfg.x.run = 3
+    cfg.x.cpn_tag = f"{year}{corr_postfix}"
+
+    # get all root processes
+    procs = get_root_processes_from_campaign(campaign)
+
+    # add processes and datasets we are interested in
+    cfg.add_process(procs.n.data)
+    data_datasets(cfg, limit_dataset_files, log=False)
+
+    cfg.add_process(procs.n.tt)
+    tt_datasets(cfg, limit_dataset_files, log=False)
+
+    cfg.add_process(procs.n.st)
+    st_datasets(cfg, limit_dataset_files, log=False)
+
+    # cfg.add_process(procs.n.w_lnu)
+    # w_lnu_datasets(cfg, limit_dataset_files, log=False)
+
+    # cfg.add_process(procs.n.dy)
+    # dy_datasets(cfg, limit_dataset_files, log=False)
+
+    # cfg.add_process(procs.n.qcd)
+    # qcd_datasets(cfg, limit_dataset_files, log=False)
+
+    cfg.add_process(procs.n.vv)
+    vv_datasets(cfg, limit_dataset_files, log=False)
+
+    # # ttbar signal processes
+    # cfg.add_process(procs.n.zprime_tt)
+    # zprime_datasets(cfg, log=True)
+
+    # cfg.add_process(procs.n.hscalar_tt)
+    # hscalar_datasets(cfg, log=True)
+
+    # cfg.add_process(procs.n.hpseudo_tt)
+    # hpseudo_datasets(cfg, log=True)
+
+    # cfg.add_process(procs.n.rsgluon_tt)
+    # rsgluon_datasets(cfg, log=True)
+
+    # set flags for signal processes (used when plotting)
+    # for process, _, _ in cfg.walk_processes():
+    #     if any(
+    #         process.name.startswith(prefix)
+    #         for prefix in [
+    #             "zprime_tt",
+    #             "hpseudo_tt",
+    #             "hscalar_tt",
+    #             "rsgluon_tt",
+    #         ]
+    #     ):
+    #         process.color1 = "#aaaaaa"
+    #         process.color2 = "#000000"
+    #         process.x.is_mtt_signal = True
+    #         process.unstack = True
+    #         process.hide_errors = True
+    #     else:
+    #         process.x.is_mtt_signal = False
+
+    # set color of main processes
+    colors = {
+        "data": "#000000",  # black
+        "tt": "#E04F21",  # red
+        "qcd": "#5E8FFC",  # blue
+        "w_lnu": "#82FF28",  # green
+        "higgs": "#984ea3",  # purple
+        "st": "#3E00FB",  # dark purple
+        "dy": "#FBFF36",  # yellow
+        "vv": "#B900FC",  # pink
+        "other": "#999999",  # grey
+        "zprime_m_500_w_???": "#000000",  # black
+        "zprime_m_1000_w_???": "#CCCCCC",  # light gray
+        "zprime_m_3000_w_???": "#666666",  # dark gray
+    }
+
+    # # process settings groups to quickly define settings for ProcessPlots
+    # cfg.x.process_settings_groups = {
+    #     "default": [
+    #         ["zprime_tt_m400_w40", "scale=2000", "unstack"],
+    #     ],
+    #     "unstack_all": [
+    #         [proc, "unstack"] for proc in cfg.processes
+    #     ],
+    # }
+
+    # zprime_base_label = r"Z'$\rightarrow$ $t\overline{t}$"
+    # zprime_mass_labels = {
+    #     "zprime_tt_m500_w50": "$m$ = 0.5 TeV",
+    #     "zprime_tt_m1000_w100": "$m$ = 1 TeV",
+    #     "zprime_tt_m3000_w300": "$m$ = 3 TeV",
+    # }
+
+    # for proc, zprime_mass_label in zprime_mass_labels.items():
+    #     proc_inst = cfg.get_process(proc)
+    #     proc_inst.label = f"{zprime_base_label} ({zprime_mass_label})"
+
+    for proc in cfg.processes:
+        cfg.get_process(proc).color1 = colors.get(proc.name, "#aaaaaa")
+        cfg.get_process(proc).color2 = colors.get(proc.name, "#000000")
+
+    # verify that the root processes of each dataset (or one of their
+    # ancestor processes) are registered in the config
+    verify_config_processes(cfg, warn=True)
+
+    # add tagger working points
+    cfg.x.btag_wp = btag_params(cfg)
+    cfg.x.toptag_wp = toptag_params(cfg)
+
+    #
+    # selector configuration
+    #
+
+    # lepton selection parameters
+    cfg.x.lepton_selection = DotDict.wrap({
+        "mu": {
+            "column": "Muon",
+            "min_pt": {
+                "low_pt": 30,
+                "high_pt": 55,
+            },
+            "max_abseta": 2.4,
+            "iso": {
+                "column": "pfIsoId",
+                "min_value": 4,  # 1 = PFIsoVeryLoose, 2 = PFIsoLoose, 3 = PFIsoMedium, 4 = PFIsoTight, 5 = PFIsoVeryTight, 6 = PFIsoVeryVeryTight  # noqa
+            },
+            "id": {
+                "low_pt": {
+                    "column": "tightId",
+                    "value": True,
+                },
+                "high_pt": {
+                    "column": "highPtId",
+                    "value": 2,  # 2 = global high pT, which includes tracker high pT
+                },
+            },
+            # veto events with additional leptons passing looser cuts
+            "min_pt_addveto": 25,
+            "id_addveto": {
+                "column": "tightId",
+                "value": True,
+            },
+            "max_abseta_addveto": 2.4,
+        },
+        "e": {
+            "column": "Electron",
+            "min_pt": {
+                "low_pt": 35,
+                "high_pt": 120,
+            },
+            "max_abseta": 2.5,
+            "barrel_veto": [1.44, 1.57],
+            "mva_id": {
+                "low_pt": "mvaIso_WP80",
+                "high_pt": "mvaNoIso_WP80",
+            },
+            # veto events with additional leptons passing looser cuts
+            "min_pt_addveto": 25,
+            "id_addveto": {
+                "column": "cutBased",
+                "min_value": 3,  # 0 = fail, 1 = veto, 2 = loose, 3 = medium, 4 = tight
+            },
+            "max_abseta_addveto": 2.5,
+        },
+    })
+
+    # jet selection parameters
+    cfg.x.jet_selection = DotDict.wrap({
+        "ak4": {
+            "column": "Jet",
+            "max_abseta": 2.5,
+            "min_pt": {
+                "baseline": 30,
+                "e": [50, 40],
+                "mu": [50, 50],
+            },
+            "btagger": {
+                "column": "btagDeepFlavB" if year != 2024 else "btagUPartAK4B",
+                "wp": cfg.x.btag_wp.deepjet.medium if year != 2024 else cfg.x.btag_wp.UPartAK4.medium,
+            },
+        },
+        "ak8": {
+            "column": "FatJet",
+            "max_abseta": 2.5,
+            "min_pt": 400,
+            "msoftdrop": [105, 210],
+            "toptagger": {
+                "column": "particleNetWithMass_TvsQCD",
+                "wp": cfg.x.toptag_wp.particle_net.tight,
+            },
+            "delta_r_lep": 0.8,
+        },
+    })
+
+    # MET selection parameters
+    cfg.x.met_selection = DotDict.wrap({
+        "column": "MET",
+        "min_pt": {
+            "e": 60,
+            "mu": 70,
+        },
+    })
+
+    # lepton jet 2D isolation parameters
+    cfg.x.lepton_jet_iso = DotDict.wrap({
+        "min_pt": 15,
+        "min_delta_r": 0.4,
+        "min_pt_rel": 25,
+    })
+
+    # trigger paths for muon/electron channels
+    # TODO update to relevant Run 3 triggers
+    cfg.x.triggers = DotDict.wrap({
+        "lowpt": {
+            "all": {
+                "triggers": {
+                    "muon": {
+                        "IsoMu27",
+                    },
+                    "electron": {
+                        "Ele35_WPTight_Gsf",
+                    },
+                },
+            },
+        },
+        "highpt": {
+            "all": {
+                "triggers": {
+                    "muon": {
+                        "Mu50",
+                        "HighPtTkMu100",
+                    },
+                    "electron": {
+                        "Ele115_CaloIdVT_GsfTrkIdT",
+                    },
+                    "photon": {
+                        "Photon200",
+                    },
+                },
+            },
+        },
+    })
+
+    #
+    # MET filters
+    #
+
+    # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#Run_3_recommendations
+    cfg.x.met_filters = {
+        "Flag.goodVertices",
+        "Flag.globalSuperTightHalo2016Filter",
+        "Flag.EcalDeadCellTriggerPrimitiveFilter",
+        "Flag.BadPFMuonFilter",
+        "Flag.BadPFMuonDzFilter",
+        "Flag.eeBadScFilter",
+        "Flag.ecalBadCalibFilter",
+    }
+
+    #
+    # luminosity
+    #
+
+    # lumi values in inverse pb
+    # https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVRun3Analysis
+    # if year == 2022:
+    #     if campaign.x.EE == "pre":
+    #         cfg.x.luminosity = Number(7971, {
+    #             "lumi_13p6TeV_2022": 0.01j,
+    #             # "lumi_13p6TeV_correlated": 0.006j,
+    #         })
+    #     elif campaign.x.EE == "post":
+    #         cfg.x.luminosity = Number(26337, {
+    #             "lumi_13p6TeV_2022": 0.01j,
+    #             # "lumi_13p6TeV_correlated": 0.006j,
+    #         })
+    # elif year == 2023:
+    # else:
+    if year == 2022 and campaign.x.EE == "pre":
+        cfg.x.luminosity = Number(7_980.4541, {
+            "lumi_13p6TeV_2022": 0.014j,
+        })
+    elif year == 2022 and campaign.x.EE == "post":
+        cfg.x.luminosity = Number(26_671.6097, {
+            "lumi_13p6TeV_2022": 0.014j,
+        })
+    elif year == 2023 and campaign.x.BPix == "pre":
+        cfg.x.luminosity = Number(18_062.6591, {
+            "lumi_13p6TeV_2023": 0.013j,
+        })
+    elif year == 2023 and campaign.x.BPix == "post":
+        cfg.x.luminosity = Number(9_693.1301, {
+            "lumi_13p6TeV_2023": 0.013j,
+        })
+    elif year == 2024:
+        cfg.x.luminosity = Number(109_080.0, {  # TODO: update number
+            "lumi_13p6TeV_2024": 0.013j,
+        })
+    else:
+        raise NotImplementedError(f"Luminosity for year {year} is not defined.")
+
+    #
+    # ttbar reconstruction parameters
+    #
+
+    # chi2 tuning parameters (mean masses/widths of top quarks
+    # with hadronically/leptonically decaying W bosons)
+    # AN2019_197_v3
+    # TODO: update to Run 3 values
+    cfg.x.chi2_parameters = DotDict.wrap({
+        "resolved": {
+            "m_had": 175.4,  # GeV
+            "s_had": 20.7,  # GeV
+            "m_lep": 175.0,  # GeV
+            "s_lep": 23.3,  # GeV
+        },
+        "boosted": {
+            "m_had": 182.3,  # GeV
+            "s_had": 16.1,  # GeV
+            "m_lep": 172.2,  # GeV
+            "s_lep": 21.7,  # GeV
+        },
+    })
+
+    # parameters to fine-tune the ttbar combinatoric
+    # reconstruction
+    cfg.x.ttbar_reco_settings = DotDict.wrap({
+        # -- minimal settings (fast runtime)
+        # "n_jet_max": 9,
+        # "n_jet_lep_range": (1, 1),
+        # "n_jet_had_range": (3, 3),
+        # "n_jet_ttbar_range": (4, 4),
+        # "max_chunk_size": 100000,
+
+        # -- default settings
+        "n_jet_max": 9,
+        "n_jet_lep_range": (1, 2),
+        "n_jet_had_range": (1, 6),
+        "n_jet_ttbar_range": (2, 6),
+        "max_chunk_size": (
+            lambda dataset_inst:
+                10000 if dataset_inst.has_tag("has_memory_intensive_reco")
+                else 30000
+        ),
+
+        # -- "maxed out" settings (very slow)
+        # "n_jet_max": 10,
+        # "n_jet_lep_range": (1, 8),
+        # "n_jet_had_range": (1, 9),
+        # "n_jet_ttbar_range": (2, 10),
+        # "max_chunk_size": 10000,
+    })
+
+    # working points for event categorization
+    cfg.x.categorization = DotDict({
+        "chi2_max": 30,
+    })
+
+    #
+    # cross sections
+    #
+
+    # cross sections for diboson samples; taken from:
+    # - ww (NNLO): https://arxiv.org/abs/1408.5243
+    # - wz (NLO): https://arxiv.org/abs/1105.0020
+    # - zz (NNLO): https://www.sciencedirect.com/science/article/pii/S0370269314004614?via%3Dihub
+    diboson_xsecs_13 = {
+        "ww": Number(118.7, {"scale": (0.025j, 0.022j)}),
+        "wz": Number(46.74, {"scale": (0.041j, 0.033j)}),
+        # "wz": Number(28.55, {"scale": (0.041j, 0.032j)}) + Number(18.19, {"scale": (0.041j, 0.033j)}),  # (W+Z) + (W-Z)  # noqa
+        "zz": Number(16.99, {"scale": (0.032j, 0.024j)}),
+    }
+    # TODO Use 14 TeV xs for Run 3?
+    diboson_xsecs_14 = {
+        "ww": Number(131.1, {"scale": (0.026j, 0.022j)}),
+        "wz": Number(67.06, {"scale": (0.039j, 0.031j)}),
+        # "wz": Number(31.50, {"scale": (0.039j, 0.030j)}) + Number(20.32, {"scale": (0.039j, 0.031j)}),  # (W+Z) + (W-Z)  # noqa
+        "zz": Number(18.77, {"scale": (0.032j, 0.024j)}),
+    }
+
+    # linear interpolation between 13 and 14 TeV
+    diboson_xsecs_13_6 = {
+        ds: diboson_xsecs_13[ds] + (13.6 - 13.0) * (diboson_xsecs_14[ds] - diboson_xsecs_13[ds]) / (14.0 - 13.0)
+        for ds in diboson_xsecs_13.keys()  # ww: 125.8 wz: 58.932 zz: 18.058  noqa
+    }
+
+    for ds in diboson_xsecs_14:
+        procs.n(ds).set_xsec(13.6, diboson_xsecs_13_6[ds])
+
+    #
+    # systematic shifts
+    #
+
+    # read in JEC sources from file
+    with open(os.path.join(thisdir, "jec_sources.yaml"), "r") as f:
+        all_jec_sources = yaml.load(f, yaml.Loader)["names"]
+
+    # declare the shifts
+    def add_shifts(cfg):
+        # nominal shift
+        cfg.add_shift(name="nominal", id=0)
+
+        # tune shifts are covered by dedicated, varied datasets, so tag the shift as "disjoint_from_nominal"
+        # (this is currently used to decide whether ML evaluations are done on the full shifted dataset)
+        cfg.add_shift(name="tune_up", id=1, type="shape", tags={"disjoint_from_nominal"})
+        cfg.add_shift(name="tune_down", id=2, type="shape", tags={"disjoint_from_nominal"})
+
+        cfg.add_shift(name="hdamp_up", id=3, type="shape", tags={"disjoint_from_nominal"})
+        cfg.add_shift(name="hdamp_down", id=4, type="shape", tags={"disjoint_from_nominal"})
+
+        # pileup / minimum bias cross section variations
+        cfg.add_shift(name="minbias_xs_up", id=7, type="shape")
+        cfg.add_shift(name="minbias_xs_down", id=8, type="shape")
+        add_shift_aliases(cfg, "minbias_xs", {"pu_weight": "pu_weight_{name}"})
+
+        # top pt reweighting
+        cfg.add_shift(name="top_pt_up", id=9, type="shape")
+        cfg.add_shift(name="top_pt_down", id=10, type="shape")
+        add_shift_aliases(cfg, "top_pt", {"top_pt_weight": "top_pt_weight_{direction}"})
+
+        # renormalization scale
+        cfg.add_shift(name="mur_up", id=901, type="shape")
+        cfg.add_shift(name="mur_down", id=902, type="shape")
+
+        # factorization scale
+        cfg.add_shift(name="muf_up", id=903, type="shape")
+        cfg.add_shift(name="muf_down", id=904, type="shape")
+
+        # scale variation (?)
+        cfg.add_shift(name="scale_up", id=905, type="shape")
+        cfg.add_shift(name="scale_down", id=906, type="shape")
+
+        # pdf variations
+        cfg.add_shift(name="pdf_up", id=951, type="shape")
+        cfg.add_shift(name="pdf_down", id=952, type="shape")
+
+        # alpha_s variation
+        cfg.add_shift(name="alpha_up", id=961, type="shape")
+        cfg.add_shift(name="alpha_down", id=962, type="shape")
+
+        # TODO: murf_envelope?
+        for unc in ["mur", "muf", "scale", "pdf", "alpha"]:
+            add_shift_aliases(cfg, unc, {
+                # TODO: normalized?
+                f"{unc}_weight": f"{unc}_weight_{{direction}}",
+            })
+
+        # event weights due to muon scale factors
+        if not cfg.has_tag("skip_muon_weights"):
+            cfg.add_shift(name="muon_up", id=111, type="shape")
+            cfg.add_shift(name="muon_down", id=112, type="shape")
+            add_shift_aliases(cfg, "muon", {"muon_weight": "muon_weight_{direction}"})
+
+        # event weights due to electron scale factors
+        if not cfg.has_tag("skip_electron_weights"):
+            cfg.add_shift(name="electron_up", id=121, type="shape")
+            cfg.add_shift(name="electron_down", id=122, type="shape")
+            add_shift_aliases(cfg, "electron", {"electron_weight": "electron_weight_{direction}"})
+
+        # V+jets reweighting
+        cfg.add_shift(name="vjets_up", id=201, type="shape")
+        cfg.add_shift(name="vjets_down", id=202, type="shape")
+        add_shift_aliases(cfg, "vjets", {"vjets_weight": "vjets_weight_{direction}"})
+
+        # b-tagging shifts
+        btag_uncs = [
+            "hf", "lf",
+            f"hfstats1_{year}", f"hfstats2_{year}",
+            f"lfstats1_{year}", f"lfstats2_{year}",
+            "cferr1", "cferr2",
+        ]
+        for i, unc in enumerate(btag_uncs):
+            cfg.add_shift(name=f"btag_{unc}_up", id=501 + 2 * i, type="shape")
+            cfg.add_shift(name=f"btag_{unc}_down", id=502 + 2 * i, type="shape")
+            add_shift_aliases(
+                cfg,
+                f"btag_{unc}",
+                {
+                    # taken from
+                    # https://github.com/uhh-cms/hh2bbww/blob/c6d4ee87a5c970660497e52aed6b7ebe71125d20/hbw/config/config_run2.py#L421
+                    "normalized_btag_weight": f"normalized_btag_weight_{unc}_" + "{direction}",
+                    "normalized_njet_btag_weight": f"normalized_njet_btag_weight_{unc}_" + "{direction}",
+                    "btag_weight": f"btag_weight_{unc}_" + "{direction}",
+                    "njet_btag_weight": f"njet_btag_weight_{unc}_" + "{direction}",
+                },
+            )
+
+        # jet energy scale (JEC) uncertainty variations
+        for jec_source in cfg.x.jec.Jet.uncertainty_sources:
+            idx = all_jec_sources.index(jec_source)
+            cfg.add_shift(name=f"jec_{jec_source}_up", id=5000 + 2 * idx, type="shape", tags={"jec"})
+            cfg.add_shift(name=f"jec_{jec_source}_down", id=5001 + 2 * idx, type="shape", tags={"jec"})
+            add_shift_aliases(
+                cfg,
+                f"jec_{jec_source}",
+                {
+                    "Jet.pt": "Jet.pt_{name}",
+                    "Jet.mass": "Jet.mass_{name}",
+                    "MET.pt": "MET.pt_{name}",
+                },
+            )
+
+        # jet energy resolution (JER) scale factor variations
+        cfg.add_shift(name="jer_up", id=6000, type="shape")
+        cfg.add_shift(name="jer_down", id=6001, type="shape")
+        add_shift_aliases(
+            cfg,
+            "jer",
+            {
+                "Jet.pt": "Jet.pt_{name}",
+                "Jet.mass": "Jet.mass_{name}",
+                "MET.pt": "MET.pt_{name}",
+            },
+        )
+
+        # PSWeight variations
+        cfg.add_shift(name="ISR_up", id=7001, type="shape")  # PS weight [0] ISR=2 FSR=1
+        cfg.add_shift(name="ISR_down", id=7002, type="shape")  # PS weight [2] ISR=0.5 FSR=1
+        add_shift_aliases(cfg, "ISR", {"ISR": "ISR_{direction}"})
+
+        cfg.add_shift(name="FSR_up", id=7003, type="shape")  # PS weight [1] ISR=1 FSR=2
+        cfg.add_shift(name="FSR_down", id=7004, type="shape")  # PS weight [3] ISR=1 FSR=0.5
+        add_shift_aliases(cfg, "FSR", {"FSR": "FSR_{direction}"})
+
+    #
+    # corrections
+    #
+
+    cfg.x.vjets_reweighting = vjets_reweighting()
+    cfg.x.jec, cfg.x.jer = jerc(campaign, year)
+    # add the shifts
+    add_shifts(cfg)
+    cfg.x.btag_sf = btag_sf(year)
+    cfg.x.toptag_sf = toptag_sf()
+    cfg.x.electron_sf_names = lepton_sf(cfg, "electron").sf_names
+    cfg.x.muon_sf_names = lepton_sf(cfg, "muon").sf_names
+    cfg.x.lepton_id_sf_names = lepton_sf(cfg, "muon").id_sf_names
+    cfg.x.lepton_iso_sf_names = lepton_sf(cfg, "muon").iso_sf_names
+
+    # top pt reweighting parameters
+    # https://twiki.cern.ch/twiki/bin/viewauth/CMS/TopPtReweighting#TOP_PAG_corrections_based_on_dat?rev=31
+    cfg.x.top_pt_reweighting_params = {
+        "a": 0.0615,
+        "b": -0.0005,
+    }
+
+    #
+    # event weights
+    #
+
+    # event weight columns as keys in an OrderedDict, mapped to shift instances they depend on
+    get_shifts = functools.partial(get_shifts_from_sources, cfg)
+    cfg.x.event_weights = DotDict({
+        "normalization_weight": [],
+        "pu_weight": get_shifts("minbias_xs"),
+        "muon_weight": get_shifts("muon"),
+        # "ISR": get_shifts("ISR"),
+        # "FSR": get_shifts("FSR"),
+        # TODO: add scale and PDF weights, where available
+        # "scale_weight": ???,
+        # "pdf_weight": ???,
+    })
+
+    # optional weights
+    if not cfg.has_tag("skip_electron_weights"):
+        cfg.x.event_weights["electron_weight"] = get_shifts("electron")
+
+    # event weights only present in certain datasets
+    for dataset in cfg.datasets:
+        dataset.x.event_weights = DotDict()
+
+        # TTbar: top pt reweighting
+        if dataset.has_tag("is_ttbar"):
+            dataset.x.event_weights["top_pt_weight"] = get_shifts("top_pt")
+
+        # V+jets: QCD NLO reweighting (disable for now)
+        # if dataset.has_tag("is_v_jets"):
+        #     dataset.x.event_weights["vjets_weight"] = get_shifts("vjets")
+
+    #
+    # external files
+    # setup taken from https://github.com/uhh-cms/hh2bbtautau/blob/ed8f363ac239b0257fc7f470b96f5c09a0572c34/hbt/config/configs_hbt.py#L1574  # noqa: E501
+    # https://cms-analysis-corrections.docs.cern.ch
+    #
+
+    cfg.x.external_files = DotDict()
+
+    # helper
+    def add_external(name, value):
+        if isinstance(value, dict):
+            value = DotDict.wrap(value)
+        cfg.x.external_files[name] = value
+
+    # prepare run/era/nano meta data info to determine files in the CAT metadata structure
+    # see https://cms-analysis-corrections.docs.cern.ch
+    cat_info = {
+        (2022, "", 12): CATInfo(
+            run=3,
+            vnano=12,
+            era="22CDSep23-Summer22",
+            pog_directories={"dc": "Collisions22"},
+            snapshot=CATSnapshot(btv="2025-08-20", dc="2025-07-25", egm="2025-04-15", jme="2025-09-23", lum="2024-01-31", muo="2025-08-14", tau="2025-10-01"),  # noqa: E501
+        ),
+        (2022, "EE", 12): CATInfo(
+            run=3,
+            vnano=12,
+            era="22EFGSep23-Summer22EE",
+            pog_directories={"dc": "Collisions22"},
+            snapshot=CATSnapshot(btv="2025-08-20", dc="2025-07-25", egm="2025-04-15", jme="2025-10-07", lum="2024-01-31", muo="2025-08-14", tau="2025-10-01"),  # noqa: E501
+        ),
+        (2023, "", 12): CATInfo(
+            run=3,
+            vnano=12,
+            era="23CSep23-Summer23",
+            # pog_eras={"tau": "23CSep23-Summer22"},  # TODO: remove once typo in CAT repo is fixed
+            pog_directories={"dc": "Collisions23"},
+            snapshot=CATSnapshot(btv="2025-08-20", dc="2025-07-25", egm="2025-04-15", jme="2025-10-07", lum="2024-01-31", muo="2025-08-14", tau="2025-10-01"),  # noqa: E501
+        ),
+        (2023, "BPix", 12): CATInfo(
+            run=3,
+            vnano=12,
+            era="23DSep23-Summer23BPix",
+            pog_directories={"dc": "Collisions23"},
+            snapshot=CATSnapshot(btv="2025-08-20", dc="2025-07-25", egm="2025-04-15", jme="2025-10-07", lum="2024-01-31", muo="2025-08-14", tau="2025-10-01"),  # noqa: E501
+        ),
+        (2024, "", 15): CATInfo(
+            run=3,
+            vnano=15,
+            era="24CDEReprocessingFGHIPrompt-Summer24",
+            pog_directories={"dc": "Collisions24"},
+            # TODO: tau and lum not yet available
+            snapshot=CATSnapshot(btv="2025-08-19", dc="2025-07-25", egm="2025-08-15", jme="2025-07-17", muo="2025-08-27"),  # noqa: E501
+        ),
+    }[(year, campaign.x.postfix, vnano)]
+    cfg.x.cat_info = cat_info
+
+    # common files
+    # (versions in the end are for hashing in cases where file contents changed but paths did not)
+    add_external("lumi", {
+        "golden": {
+            # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVRun3Analysis?rev=161#Year_2022
+            2022: (cat_info.get_file("dc", "Cert_Collisions2022_355100_362760_Golden.json"), "v1"),
+            # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVRun3Analysis?rev=161#Year_2023
+            2023: (cat_info.get_file("dc", "Cert_Collisions2023_366442_370790_Golden.json"), "v1"),
+            # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVRun3Analysis?rev=180#Year_2024
+            # not yet available at CAT space
+            # 2024: (cat_info.get_file("dc", "Cert_Collisions2024_378981_386951_Golden.json"), "v1"),
+            2024: ("https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions24/Cert_Collisions2024_378981_386951_Golden.json", "v1"),  # noqa: E501
+        }[year],
+        "normtag": {
+            # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVRun3Analysis?rev=161#Year_2022
+            2022: ("/cvmfs/cms-bril.cern.ch/cms-lumi-pog/Normtags/normtag_BRIL.json", "v1"),
+            # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVRun3Analysis?rev=161#Year_2023
+            2023: ("/cvmfs/cms-bril.cern.ch/cms-lumi-pog/Normtags/normtag_BRIL.json", "v1"),
+            # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVRun3Analysis?rev=180#Year_2024
+            2024: ("/cvmfs/cms-bril.cern.ch/cms-lumi-pog/Normtags/normtag_BRIL.json", "v1"),  # TODO: correct?
+        }[year],
+    })
+    # pileup weight corrections
+    if year != 2024:  # TODO: not yet available, see https://cms-analysis-corrections.docs.cern.ch
+        add_external("pu_sf", (cat_info.get_file("lum", "puWeights.json.gz"), "v1"))
+    # jet energy correction
+    add_external("jet_jerc", (cat_info.get_file("jme", "jet_jerc.json.gz"), "v1"))
+    # jet veto map
+    add_external("jet_veto_map", (cat_info.get_file("jme", "jetvetomaps.json.gz"), "v1"))
+    # btag scale factor
+    add_external("btag_sf_corr", (cat_info.get_file("btv", "btagging.json.gz"), "v1"))
+
+    # updated jet id
+    add_external("jet_id", (cat_info.get_file("jme", "jetid.json.gz"), "v1"))
+    # muon scale factors
+    add_external("muon_sf", (cat_info.get_file("muo", "muon_Z.json.gz"), "v1"))
+    # met phi correction
+    if year != 2024:  # TODO: not yet available
+        add_external("met_phi_corr", (cat_info.get_file("jme", f"met_xyCorrections_{year}_{year}{campaign.x.postfix}.json.gz"), "v1"))  # noqa: E501
+    # electron scale factors
+    # TODO: the postfix will be obsolete soon, see https://gitlab.cern.ch/cms-analysis-corrections/EGM/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/-/issues/1 # noqa: E501
+    egm_postfix = "_v1" if year == 2024 else ""
+    add_external("electron_sf", (cat_info.get_file("egm", f"electron{egm_postfix}.json.gz"), "v1"))
+    # electron energy correction and smearing
+    add_external("electron_ss", (cat_info.get_file("egm", f"electronSS_EtDependent{egm_postfix}.json.gz"), "v1"))  # FIXME correct for us? # noqa: E501
+
+    # # top-tagging scale factors (TODO)
+    # "toptag_sf": (f"{sources['jet']}/JMAR/???/???.json", "v1"),  # noqa
+
+    # # V+jets reweighting
+    # "vjets_reweighting": f"{sources['local_repo']}/data/json/vjets_reweighting.json",
+
+    # # temporary fix due to missing corrections in run 3
+    # cfg.x.external_files.pop("met_phi_corr")
+
+    # if year == 2022 and campaign.x.EE == "pre":
+    #     cfg.x.external_files.update(DotDict.wrap({
+    #         # lumi files from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGoodLumiSectionsJSONFile
+    #         "lumi": {
+    #             "golden": (f"{sources['cert']}/Cert_Collisions2022_355100_362760_Golden.json", "v1"),  # noqa
+    #             "normtag": ("/afs/cern.ch/user/l/lumipro/public/Normtags/normtag_PHYSICS.json", "v1"),
+    #         },
+
+    #         # pileup files (for PU reweighting)
+    #         "pu": {
+    #             # "json": (f"https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/PileUp/BCD/pileup_JSON.txt", "v1"),  # noqa
+    #             "json": (f"https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/PileUp/BCDEFG/pileup_JSON.txt", "v1"),  # noqa
+    #             "mc_profile": ("https://raw.githubusercontent.com/cms-sw/cmssw/bb525104a7ddb93685f8ced6fed1ab793b2d2103/SimGeneral/MixingModule/python/Run3_2022_LHC_Simulation_10h_2h_cfi.py", "v1"),  # noqa
+    #             "data_profile": {
+    #                 # "nominal": (f"https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/PileUp/BCD/pileupHistogram-Cert_Collisions2022_355100_357900_eraBCD_GoldenJson-13p6TeV-69200ub-99bins.root", "v1"),  # noqa
+    #                 # "minbias_xs_up": (f"https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/PileUp/BCD/pileupHistogram-Cert_Collisions2022_355100_357900_eraBCD_GoldenJson-13p6TeV-72400ub-99bins.root", "v1"),  # noqa
+    #                 # "minbias_xs_down": (f"https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/PileUp/BCD/pileupHistogram-Cert_Collisions2022_355100_357900_eraBCD_GoldenJson-13p6TeV-66000ub-99bins.root", "v1"),  # noqa
+    #                 "nominal": (f"/afs/cern.ch/user/a/anhaddad/public/Collisions22/pileupHistogram-Cert_Collisions2022_355100_362760_GoldenJson-13p6TeV-69200ub-100bins.root", "v1"),  # noqa
+    #                 "minbias_xs_up": (f"/afs/cern.ch/user/a/anhaddad/public/Collisions22/pileupHistogram-Cert_Collisions2022_355100_362760_GoldenJson-13p6TeV-72400ub-100bins.root", "v1"),  # noqa
+    #                 "minbias_xs_down": (f"/afs/cern.ch/user/a/anhaddad/public/Collisions22/pileupHistogram-Cert_Collisions2022_355100_362760_GoldenJson-13p6TeV-66000ub-100bins.root", "v1"),  # noqa
+    #             },
+    #         },
+    #     }))
+    # elif year == 2022 and campaign.x.EE == "post":
+    #     cfg.x.external_files.update(DotDict.wrap({
+    #         # files from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGoodLumiSectionsJSONFile
+    #         "lumi": {
+    #             "golden": ("https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/Cert_Collisions2022_355100_362760_Golden.json", "v1"),  # noqa
+    #             "normtag": ("/afs/cern.ch/user/l/lumipro/public/Normtags/normtag_PHYSICS.json", "v1"),
+    #         },
+
+    #         # pileup files (for PU reweighting)
+    #         "pu": {
+    #             # "json": (f"https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/PileUp/EFG/pileup_JSON.txt", "v1"),  # noqa
+    #             "json": (f"https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/PileUp/BCDEFG/pileup_JSON.txt", "v1"),  # noqa
+    #             "mc_profile": ("https://raw.githubusercontent.com/cms-sw/cmssw/bb525104a7ddb93685f8ced6fed1ab793b2d2103/SimGeneral/MixingModule/python/Run3_2022_LHC_Simulation_10h_2h_cfi.py", "v1"),  # noqa
+    #             "data_profile": {
+    #                 # data profiles were produced with 99 bins instead of 100 --> use custom produced data profiles instead  # noqa
+    #                 # "nominal": (f"https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/PileUp/EFG/pileupHistogram-Cert_Collisions2022_359022_362760_eraEFG_GoldenJson-13p6TeV-69200ub-99bins.root", "v1"),  # noqa
+    #                 # "minbias_xs_up": (f"https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/PileUp/EFG/pileupHistogram-Cert_Collisions2022_359022_362760_eraEFG_GoldenJson-13p6TeV-72400ub-99bins.root", "v1"),  # noqa
+    #                 # "minbias_xs_down": (f"https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/PileUp/EFG/pileupHistogram-Cert_Collisions2022_359022_362760_eraEFG_GoldenJson-13p6TeV-66000ub-99bins.root", "v1"),  # noqa
+    #                 "nominal": (f"/afs/cern.ch/user/a/anhaddad/public/Collisions22/pileupHistogram-Cert_Collisions2022_355100_362760_GoldenJson-13p6TeV-69200ub-100bins.root", "v1"),  # noqa
+    #                 "minbias_xs_up": (f"/afs/cern.ch/user/a/anhaddad/public/Collisions22/pileupHistogram-Cert_Collisions2022_355100_362760_GoldenJson-13p6TeV-72400ub-100bins.root", "v1"),  # noqa
+    #                 "minbias_xs_down": (f"/afs/cern.ch/user/a/anhaddad/public/Collisions22/pileupHistogram-Cert_Collisions2022_355100_362760_GoldenJson-13p6TeV-66000ub-100bins.root", "v1"),  # noqa
+    #             },
+    #         },
+    #     }))
+    # else:
+    #     raise NotImplementedError(f"No lumi and pu files provided for year {year}")
+
+    #
+    # set defaults for
+    # calibrator, selector etc
+    # process, dataset, category, variable, shift groups
+    #
+
+    set_defaults(cfg)
+    set_process_groups(cfg)
+    set_dataset_groups(cfg)
+    set_category_groups(cfg)
+    set_variables_groups(cfg)
+    set_shift_groups(cfg)
+    set_selector_steps(cfg)
+
+    # columns to keep after certain steps
+    cfg.x.keep_columns = DotDict.wrap({
+        "cf.MergeSelectionMasks": {
+            "mc_weight", "normalization_weight", "process_id", "category_ids", "cutflow.*",
+        },
+        "cf.ReduceEvents": {
+            #
+            # NanoAOD columns
+            #
+
+            # general event info
+            "run", "luminosityBlock", "event",
+
+            # weights
+            "genWeight",
+            "LHEWeight.*",
+            "LHEPdfWeight",
+            "LHEScaleWeight",
+            "PSWeight",
+
+            # muons
+            "{Muon,VetoMuon}.{pt,eta,phi,mass}",
+            "Muon.pfRelIso04_all",
+            # electrons
+            "{Electron,VetoElectron}.{pt,eta,phi,mass}",
+            "Electron.{deltaEtaSC,pfRelIso03_all}",
+
+            # photons (for L1 prefiring)
+            "Photon.{pt,eta,phi,mass,jetIdx}",
+
+            # AK4 jets
+            "{Jet,BJet,LightJet}.{pt,eta,phi,mass,btagDeepFlavB,hadronFlavour}",
+            "Jet.rawFactor",
+
+            # AK8 jets
+            "{FatJet,FatJetTopTag,FatJetTopTagDeltaRLepton}.{pt,eta,phi,mass,rawFactor}",
+            "{FatJet,FatJetTopTag}.{msoftdrop,particleNetWithMass_TvsQCD,deepTagMD_TvsQCD}",
+            "{FatJet,FatJetTopTag,FatJetTopTagDeltaRLepton}.{tau1,tau2,tau3}",
+            "FatJetTopTagDeltaRLepton.msoftdrop",
+            "FatJetTopTagDeltaRLepton.deepTagDeltaRLeptonMD_TvsQCD",
+
+            # generator quantities
+            "Generator.*",
+
+            # generator particles
+            "GenPart.*",
+
+            # generator objects
+            "GenMET.*",
+            "GenJet.*",
+            "GenJetAK8.*",
+
+            # missing transverse momentum
+            "MET.{pt,phi,significance,covXX,covXY,covYY}",
+
+            # number of primary vertices
+            "PV.npvs",
+
+            # average number of pileup interactions
+            "Pileup.nTrueInt",
+
+            #
+            # columns added during selection
+            #
+
+            # generator particle info
+            "GenTopDecay.*",
+            "GenPartonTop.*",
+            "GenVBoson.*",
+
+            # generic leptons (merger of Muon/Electron)
+            "Lepton.*",
+
+            # columns for PlotCutflowVariables
+            "cutflow.*",
+
+            # other columns, required by various tasks
+            "channel_id", "category_ids", "process_id",
+            "deterministic_seed",
+            "mc_weight",
+            "pt_regime",
+            "pu_weight*",
+        },
+    })
+
+    # versions per task family and optionally also dataset and shift
+    # None can be used as a key to define a default value
+    cfg.x.versions = {}
+
+    #
+    # finalization
+    #
+
+    # add channels
+    cfg.add_channel("e", id=1)
+    cfg.add_channel("mu", id=2)
+
+    # add categories
+    add_categories_selection(cfg)
+
+    # add variables
+    add_variables(cfg)
+
+    return cfg

--- a/mtt/config/taggers.py
+++ b/mtt/config/taggers.py
@@ -1,0 +1,173 @@
+# coding: utf-8
+
+"""
+Configuration of taggers for the m(ttbar) analysis.
+"""
+
+import order as od
+
+from columnflow.util import DotDict
+
+
+def btag_params(
+        config: od.Config,
+) -> DotDict:
+    """
+    Returns the b-tagging parameters for the given config.
+    b-tagging working points from
+    2017:       https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL17?rev=15
+    2022preEE:  https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer22/
+    2022postEE: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer22EE/
+    2023preBPix: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer23/
+    2024:       https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer24/
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    wp_values = {
+        2: {
+            "2017": {
+                "deepjet": {
+                    "loose": 0.0532,
+                    "medium": 0.3040,
+                    "tight": 0.7476,
+                },
+                "deepcsv": {
+                    "loose": 0.1355,
+                    "medium": 0.4506,
+                    "tight": 0.7738,
+                },
+            }
+        },
+        3: {
+            "2022preEE": {
+                "deepjet": {
+                    "loose": 0.0583,
+                    "medium": 0.3086,
+                    "tight": 0.7183,
+                },
+                # "deepcsv": {
+                #     "loose": 0.1208,
+                #     "medium": 0.4168,
+                #     "tight": 0.7665,
+                # },
+            },
+            "2022postEE": {
+                "deepjet": {
+                    "loose": 0.0614,
+                    "medium": 0.3196,
+                    "tight": 0.7300,
+                },
+                # "deepcsv": {
+                #     "loose": 0.1208,
+                #     "medium": 0.4168,
+                #     "tight": 0.7665,
+                # },
+            },
+            "2023preBPix": {
+                "deepjet": {
+                    "loose": 0.0479,
+                    "medium": 0.2431,
+                    "tight": 0.6553,
+                },
+                # "deepcsv": {
+                #     "loose": 0.1208,
+                #     "medium": 0.4168,
+                #     "tight": 0.7665,
+                # },
+            },
+            "2023postBPix": {
+                "deepjet": {
+                    "loose": 0.048,
+                    "medium": 0.2435,
+                    "tight": 0.6563,
+                },
+                # "deepcsv": {
+                #     "loose": 0.1208,
+                #     "medium": 0.4168,
+                #     "tight": 0.7665,
+                # },
+            },
+            "2024": {
+                "UPartAK4": {
+                    "loose": 0.0246,
+                    "medium": 0.1272,
+                    "tight": 0.4648,
+                }
+            }
+        }
+    }
+
+    return DotDict.wrap(wp_values[run][tag])
+
+
+def toptag_params(
+        config: od.Config,
+) -> DotDict:
+    """
+    Returns the top-tagging parameters for the given config.
+    Top-tagging working points from
+    2017 (DeepAK8, 1% mistag rate):
+        https://twiki.cern.ch/twiki/bin/viewauth/CMS/DeepAK8Tagging2018WPsSFs?rev=4
+    Particle Net (2022, from JMAR presentation 21.10.24 (slide 10)):
+        https://indico.cern.ch/event/1459087/contributions/6173396/attachments/2951723/5188840/SF_Run3.pdf
+    Particle Net (2023, from JMAR presentation 08.09.25 (slide 3)):
+        https://indico.cern.ch/event/1582638/contributions/6670184/subcontributions/569885/attachments/3130712/5553828/WP%20JMAR%20presentation.pdf  # noqa: E501
+    """
+    run = config.campaign.x.run
+    tag = config.x.cpn_tag
+
+    wp_values = {
+        2: {
+            "2017": {
+                "deepak8": {
+                    # regular tagger
+                    "top": 0.725,
+                    "w": 0.925,
+                    # mass-decorrelated tagger
+                    "top_md": 0.344,
+                    "w_md": 0.739,
+                },
+            },
+        },
+        3: {
+            "2022preEE": {
+                "particle_net": {
+                    "medium": 0.683,
+                    "tight": 0.858,
+                    "very_tight": 0.979,
+                },
+            },
+            "2022postEE": {
+                "particle_net": {
+                    "medium": 0.698,
+                    "tight": 0.866,
+                    "very_tight": 0.980,
+                },
+            },
+            "2023preBPix": {
+                "particle_net": {
+                    "medium": 0.655,
+                    "tight": 0.835,
+                    "very_tight": 0.976,
+                },
+            },
+            "2023postBPix": {
+                "particle_net": {
+                    "medium": 0.639,
+                    "tight": 0.821,
+                    "very_tight": 0.974,
+                },
+            },
+            "2024": {
+                # FIXME: placeholder values, need to be updated when official values are available
+                "particle_net": {
+                    "medium": 0.639,
+                    "tight": 0.821,
+                    "very_tight": 0.974,
+                },
+            },
+        },
+    }
+
+    return DotDict.wrap(wp_values[run][tag])

--- a/mtt/config/taggers.py
+++ b/mtt/config/taggers.py
@@ -89,11 +89,17 @@ def btag_params(
                 # },
             },
             "2024": {
-                "UPartAK4": {
+                "UParTAK4": {
                     "loose": 0.0246,
                     "medium": 0.1272,
                     "tight": 0.4648,
-                }
+                },
+                "particle_net": {
+                    # FIXME: placeholder values, need to be updated when official values are available
+                    "loose": 0.0246,
+                    "medium": 0.1272,
+                    "tight": 0.4648,
+                },
             }
         }
     }
@@ -166,6 +172,12 @@ def toptag_params(
                     "tight": 0.821,
                     "very_tight": 0.974,
                 },
+                # FIXME: placeholder values, need to be updated when official values are available
+                "GloParTv3": {
+                    "medium": 0.639,
+                    "tight": 0.821,
+                    "very_tight": 0.974,
+                }
             },
         },
     }

--- a/mtt/config/variables.py
+++ b/mtt/config/variables.py
@@ -95,6 +95,36 @@ def add_variables(config: od.Config) -> None:
         },
     )
 
+    config.add_variable(
+        name="fatjet_tau21",
+        expression=lambda events: events.FatJet["tau2"] / events.FatJet["tau1"],
+        binning=(24 // 2, 0, 1.2),
+        x_title=r"FatJet $\tau_{{21}}$",
+        aux={
+            "inputs": {"FatJet.tau2", "FatJet.tau1"},
+            "short_label": "$\tau_{2}/\tau_{1}$",
+        },
+    )
+
+    config.add_variable(
+        name="fatjet_tau1",
+        expression="FatJet.tau1",
+        binning=(24 // 2, 0, 1.2),
+        x_title=r"FatJet $\tau_{1}$",
+    )
+    config.add_variable(
+        name="fatjet_tau2",
+        expression="FatJet.tau2",
+        binning=(24 // 2, 0, 1.2),
+        x_title=r"FatJet $\tau_{2}$",
+    )
+    config.add_variable(
+        name="fatjet_tau3",
+        expression="FatJet.tau3",
+        binning=(24 // 2, 0, 1.2),
+        x_title=r"FatJet $\tau_{3}$",
+    )
+
     # Leptons
     for obj in ["Electron", "Muon"]:
         config.add_variable(
@@ -139,6 +169,21 @@ def add_variables(config: od.Config) -> None:
     config.add_variable(
         name="met_phi",
         expression="MET.phi",
+        null_value=EMPTY_FLOAT,
+        binning=(40, -3.2, 3.2),
+        x_title=r"MET $\phi$",
+    )
+    config.add_variable(
+        name="puppi_met_pt",
+        expression="PuppiMET.pt",
+        null_value=EMPTY_FLOAT,
+        binning=(40, 0., 400.),
+        unit="GeV",
+        x_title=r"MET",
+    )
+    config.add_variable(
+        name="puppi_met_phi",
+        expression="PuppiMET.phi",
         null_value=EMPTY_FLOAT,
         binning=(40, -3.2, 3.2),
         x_title=r"MET $\phi$",
@@ -219,6 +264,22 @@ def add_variables(config: od.Config) -> None:
         y_title="Events",
     )
     config.add_variable(
+        name="ttbar_mass_ext",
+        expression="TTbar.mass",
+        # binning=[
+        #     0, 400, 600, 800, 1000, 1200, 1400,
+        #     1600, 1800, 2000, 2200, 2400, 2600,
+        #     2800, 3000, 3200, 3400, 3600, 3800,
+        #     4000, 4400, 4800, 5200, 5600, 6000,
+        #     6400, 6800, 7200, 7600, 8000, 8400,
+        #     # 8800, 9200, 9600, 10000, 10400, 10800,
+        # ],
+        binning=(30, 0, 8400),
+        unit="GeV",
+        x_title=r"$m({t}\overline{t})$",
+        y_title="Events",
+    )
+    config.add_variable(
         name="ttbar_mass_narrow",
         expression="TTbar.mass",
         binning=(100, 400, 4400),
@@ -276,6 +337,14 @@ def add_variables(config: od.Config) -> None:
         y_title="Events",
     )
     config.add_variable(
+        name="gen_ttbar_mass_ext",
+        expression="TTbar.gen_mass",
+        binning=config.get_variable("ttbar_mass_ext").binning,
+        unit="GeV",
+        x_title=r"$m({t}\overline{t})^{gen}$",
+        y_title="Events",
+    )
+    config.add_variable(
         name="gen_ttbar_mass_narrow",
         expression="TTbar.gen_mass",
         binning=config.get_variable("ttbar_mass_narrow").binning,
@@ -322,6 +391,24 @@ def add_variables(config: od.Config) -> None:
                 unit=var_unit,
                 x_title=rf"${var_label}({{t}}_{{{decay}}}^{{gen}})$",
             )
+
+    config.add_variable(
+        name="gen_ttbar_mass_unmatched_ext",
+        expression="GenTTbar.ttbar_mass",
+        binning=config.get_variable("ttbar_mass_ext").binning,
+        unit="GeV",
+        x_title=r"$m({t}\overline{t})^{gen, unmatched}$",
+        y_title="Events",
+    )
+
+    config.add_variable(
+        name="gen_ttbar_mass_diff",
+        expression="GenTTbar.mass_diff",
+        binning=(31, -0.01, 0.01),
+        unit="GeV",
+        x_title=r"$m({t}\overline{t})^{gen, unmatched} - m({t}\overline{t})^{gen}$",
+        y_title="Events",
+    )
 
     # cutflow variables
 
@@ -416,6 +503,21 @@ def add_variables_ml(config: od.Config) -> None:
     btag_binning = (50 // 2, 0, 1)
     msoftdrop_binning = (50 // 2, 0, 500)
     tau_binning = (24 // 2, 0, 1.2)
+
+    # binning adjusted to AN v12
+    v12_pt_binning_jets = (150, 0.0, 3000.0)
+    v12_pt_binning_leptons = (50, 0.0, 1000.0)
+    v12_pt_binning_met = (150, 0.0, 1500.0)
+    v12_energy_binning_jets = (100, 0.0, 5000.0)
+    v12_energy_binning_leptons = (150, 0.0, 3000.0)
+    v12_mass_binning_jets = (50, 0.0, 300.0)
+    v12_eta_binning = (50, -2.5, 2.5)
+    v12_phi_binning = (35, -3.5, 3.5)
+    v12_btag_binning = (50, 0.0, 1.0)
+    v12_msoftdrop_binning = (50, 0.0, 500.0)
+    v12_tau_binning = (24, 0.0, 1.2)
+    v12_njets_binning = (20, 0.0, 20.0)
+    v12_nfatjets_binning = (20, 0.0, 20.0)
 
     variables = {
         "pt": [(100, 0, 3000), "$p_{T}$", "GeV"],
@@ -582,6 +684,173 @@ def add_variables_ml(config: od.Config) -> None:
             expression=f"{ns}.fatjet_tau32_{i}",
             binning=tau_binning,
             x_title=rf"ML input (AK8 jet #{i} $\tau_{{32}}$)",
+        )
+
+    config.add_variable(
+        name="AN_v12_mli_n_jet",
+        expression=f"{ns}.n_jet",
+        binning=v12_njets_binning,
+        x_title=r"ML input (# of AK4 jets) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_n_fatjet",
+        expression=f"{ns}.n_fatjet",
+        binning=v12_nfatjets_binning,
+        x_title=r"ML input (# of AK8 jets) - ANv12",
+    )
+
+    # binning adjusted variables to better compare with AN
+
+    config.add_variable(
+        name="AN_v12_mli_lepton_energy",
+        expression=f"{ns}.lepton_energy",
+        binning=v12_energy_binning_leptons,
+        unit="GeV",
+        x_title=r"ML input (Lepton $E$) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_lepton_pt",
+        expression=f"{ns}.lepton_pt",
+        binning=v12_pt_binning_leptons,
+        unit="GeV",
+        x_title=r"ML input (Lepton $p_{T}$) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_lepton_eta",
+        expression=f"{ns}.lepton_eta",
+        binning=v12_eta_binning,
+        x_title=r"ML input (Lepton $\eta$) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_lepton_phi",
+        expression=f"{ns}.lepton_phi",
+        binning=v12_phi_binning,
+        x_title=r"ML input (Lepton $\phi$) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_met_pt",
+        expression=f"{ns}.met_pt",
+        binning=v12_pt_binning_met,
+        unit="GeV",
+        x_title="ML input (Missing transverse $p_{T}$) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_met_phi",
+        expression=f"{ns}.met_phi",
+        binning=v12_phi_binning,
+        x_title=r"ML input (MET $\phi$) - ANv12",
+    )
+
+    for i in range(1, 6):
+        config.add_variable(
+            name=f"AN_v12_mli_jet_energy_{i}",
+            expression=f"{ns}.jet_energy_{i}",
+            binning=v12_energy_binning_jets,
+            unit="GeV",
+            x_title=f"ML input (AK4 jet #{i} $E$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_jet_pt_{i}",
+            expression=f"{ns}.jet_pt_{i}",
+            binning=v12_pt_binning_jets,
+            unit="GeV",
+            x_title=f"ML input (AK4 jet #{i} $p_T$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_jet_eta_{i}",
+            expression=f"{ns}.jet_eta_{i}",
+            binning=v12_eta_binning,
+            x_title=rf"ML input (AK4 jet #{i} $\eta$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_jet_phi_{i}",
+            expression=f"{ns}.jet_phi_{i}",
+            binning=v12_phi_binning,
+            x_title=rf"ML input (AK4 jet #{i} $\phi$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_jet_mass_{i}",
+            expression=f"{ns}.jet_mass_{i}",
+            binning=v12_mass_binning_jets,
+            unit="GeV",
+            x_title=f"ML input (AK4 jet #{i} $m$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_jet_btagUParTAK4B_{i}",
+            expression=f"{ns}.jet_btagUParTAK4B_{i}",
+            binning=v12_btag_binning,
+            x_title=f"ML input (AK4 jet #{i} UParTAK4B b tag score) - ANv12",
+        )
+
+    for i in range(1, 4):
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_energy_{i}",
+            expression=f"{ns}.fatjet_energy_{i}",
+            binning=v12_energy_binning_jets,
+            unit="GeV",
+            x_title=f"ML input (AK8 jet #{i} $E$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_pt_{i}",
+            expression=f"{ns}.fatjet_pt_{i}",
+            binning=v12_pt_binning_jets,
+            unit="GeV",
+            x_title=f"ML input (AK8 jet #{i} $p_T$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_eta_{i}",
+            expression=f"{ns}.fatjet_eta_{i}",
+            binning=v12_eta_binning,
+            x_title=rf"ML input (AK8 jet #{i} $\eta$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_phi_{i}",
+            expression=f"{ns}.fatjet_phi_{i}",
+            binning=v12_phi_binning,
+            x_title=rf"ML input (AK8 jet #{i} $\phi$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_msoftdrop_{i}",
+            expression=f"{ns}.fatjet_msoftdrop_{i}",
+            binning=v12_msoftdrop_binning,
+            unit="GeV",
+            x_title=f"ML input (AK8 jet #{i} $m_{{SD}}$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_tau21_{i}",
+            expression=f"{ns}.fatjet_tau21_{i}",
+            binning=v12_tau_binning,
+            x_title=rf"ML input (AK8 jet #{i} $\tau_{{21}}$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_tau32_{i}",
+            expression=f"{ns}.fatjet_tau32_{i}",
+            binning=v12_tau_binning,
+            x_title=rf"ML input (AK8 jet #{i} $\tau_{{32}}$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_tau1_{i}",
+            expression=f"{ns}.fatjet_tau1_{i}",
+            binning=tau_binning,
+            x_title=rf"ML input (AK8 jet #{i} $\tau_{{1}}$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_tau2_{i}",
+            expression=f"{ns}.fatjet_tau2_{i}",
+            binning=tau_binning,
+            x_title=rf"ML input (AK8 jet #{i} $\tau_{{2}}$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_tau3_{i}",
+            expression=f"{ns}.fatjet_tau3_{i}",
+            binning=tau_binning,
+            x_title=rf"ML input (AK8 jet #{i} $\tau_{{3}}$) - ANv12",
         )
 
     # -- helper functions

--- a/mtt/ml/simple.py
+++ b/mtt/ml/simple.py
@@ -13,7 +13,7 @@ from typing import Any, Sequence
 
 from columnflow.ml import MLModel
 from columnflow.util import maybe_import, dev_sandbox
-from columnflow.columnar_util import Route, set_ak_column, remove_ak_column
+from columnflow.columnar_util import Route, set_ak_column, remove_ak_column, ak_concatenate_safe
 from columnflow.tasks.selection import MergeSelectionStatsWrapper
 
 from mtt.config.categories import add_categories_ml
@@ -125,7 +125,7 @@ class TTbarSimpleDNN(MLModel):
 
         return produced
 
-    # -- hooks for sepcifying which ArrayFunctions to run for training
+    # -- hooks for specifying which ArrayFunctions to run for training
 
     def training_calibrators(
         self,
@@ -160,7 +160,7 @@ class TTbarSimpleDNN(MLModel):
         model = keras.models.load_model(target.path)
 
         # load the pickled model history
-        with open(f"{target.path}/model_history.pkl", "rb") as f:
+        with open(f"{target.path}_model_history.pickle", "rb") as f:
             history = pickle.load(f)
 
         return model, history
@@ -170,34 +170,43 @@ class TTbarSimpleDNN(MLModel):
         task,
         input,
     ) -> tuple[dict[str, np.array]]:
+        logger.info("Starting input preparation...")
 
         # obtain processes from config
         process_insts = [
             self.config_inst.get_process(proc)
             for proc in self.processes
         ]
+        logger.info(f"Using {len(process_insts)} processes: {[proc.name for proc in process_insts]}")
 
         proc_n_events = np.array(len(self.processes) * [0])
         proc_custom_weights = np.array(len(self.processes) * [0])
         proc_sum_weights = np.array(len(self.processes) * [0])
         proc_idx = {}  # bookkeeping which process each dataset belongs to
 
+        logger.info("Analyzing datasets and counting events...")
+
         #
         # determine process of each dataset and count number of events & sum of eventweights for this process
         #
 
         for dataset, files in input["events"][self.config_inst.name].items():
+            logger.info(f"Processing dataset: {dataset} with {len(files)} files")
+
             dataset_inst = self.config_inst.get_dataset(dataset)
 
             # check dataset only belongs to one process
             if len(dataset_inst.processes) != 1:
                 raise Exception("only 1 process inst is expected for each dataset")
 
+            logger.info(f"Loading parquet files for dataset {dataset}...")
             # TODO: use stats here instead
             mlevents = [
-                ak.from_parquet(inp["mlevents"].fn)
+                ak.from_parquet(inp["mlevents"].parent.path)
                 for inp in files
             ]
+            logger.info(f"Loaded {len(mlevents)} parquet files")
+
             n_events = sum(
                 len(events)
                 for events in mlevents
@@ -206,6 +215,7 @@ class TTbarSimpleDNN(MLModel):
                 ak.sum(events.normalization_weight)
                 for events in mlevents
             )
+            logger.info(f"Dataset {dataset}: {n_events} events, sum_weights: {sum_weights:.2f}")
 
             #
             for i, proc in enumerate(process_insts):
@@ -214,7 +224,7 @@ class TTbarSimpleDNN(MLModel):
                     p for p, _, _ in self.config_inst.get_process(proc).walk_processes(include_self=True)
                 ]
                 if dataset_inst.processes.get_first() in leaf_procs:
-                    logger.info(f"the dataset *{dataset}* is used for training the *{proc.name}* output node")
+                    logger.info(f"Dataset *{dataset}* matched to process *{proc.name}* (index {i})")
                     proc_idx[dataset] = i
                     proc_n_events[i] += n_events
                     proc_sum_weights[i] += sum_weights
@@ -224,9 +234,15 @@ class TTbarSimpleDNN(MLModel):
             if proc_idx.get(dataset) is None:
                 raise Exception(f"dataset {dataset} is not matched to any of the given processes")
 
+        logger.info("Dataset-process matching completed")
+        for i, proc in enumerate(process_insts):
+            logger.info(f"Process {proc.name}: {proc_n_events[i]} events, sum_weights: {proc_sum_weights[i]:.2f}, custom_weight: {proc_custom_weights[i]}")
+
         #
         # set inputs, weights and targets for each datset and fold
         #
+
+        logger.info("Preparing DNN inputs...")
 
         # TODO
 
@@ -238,50 +254,66 @@ class TTbarSimpleDNN(MLModel):
 
         # scaler for weights such that the largest are of order 1
         weights_scaler = min(proc_n_events / proc_custom_weights)
+        logger.info(f"Weights scaler: {weights_scaler:.6f}")
 
         sum_nnweights_processes = {}
+
+        logger.info("Processing files for neural network input...")
         for dataset, files in input["events"][self.config_inst.name].items():
             this_proc_idx = proc_idx[dataset]
-
             this_proc_name = self.processes[this_proc_idx]
             this_proc_n_events = proc_n_events[this_proc_idx]
             this_proc_sum_weights = proc_sum_weights[this_proc_idx]
 
             logger.info(
-                f"dataset: {dataset}, \n"
-                f"  #Events: {this_proc_n_events}, \n"
-                f"  Sum Eventweights: {this_proc_sum_weights}",
+                f"Processing dataset: {dataset} for process {this_proc_name}\n"
+                f"  Process index: {this_proc_idx}\n"
+                f"  #Events: {this_proc_n_events}\n"
+                f"  Sum Eventweights: {this_proc_sum_weights:.2f}"
             )
+
             sum_nnweights = 0
 
-            for inp in files:
+            for file_idx, inp in enumerate(files):
+                logger.debug(f"  Processing file {file_idx + 1}/{len(files)}: {inp['mlevents'].path}")
+
                 events = ak.from_parquet(inp["mlevents"].path)
+                logger.debug(f"  Loaded {len(events)} events from file")
+
                 weights = events.normalization_weight
                 if self.eqweight:
                     weights = weights * weights_scaler / this_proc_sum_weights
                     custom_procweight = self.proc_custom_weights[this_proc_name]
                     weights = weights * custom_procweight
+                    logger.debug(f"  Applied equal weighting with custom weight {custom_procweight}")
 
                 weights = ak.to_numpy(weights)
 
                 if np.any(~np.isfinite(weights)):
-                    raise Exception(f"Non-finite values found in weights from dataset {dataset}")
+                    raise Exception(f"Non-finite values found in weights from dataset {dataset}, file {file_idx}")
 
                 sum_nnweights += sum(weights)
                 sum_nnweights_processes.setdefault(this_proc_name, 0)
                 sum_nnweights_processes[this_proc_name] += sum(weights)
 
+                logger.debug(f"  Weights: min={np.min(weights):.6f}, max={np.max(weights):.6f}, sum={np.sum(weights):.2f}")
+
                 # remove columns not used in training
                 input_features = events[self.input_features_namespace]
+                logger.debug(f"  Available input features: {list(input_features.fields)}")
+
                 for var in input_features.fields:
                     if var not in self.input_features:
                         events = remove_ak_column(events, f"{self.input_features_namespace}.{var}")
+                        logger.debug(f"  Removed unused feature: {var}")
 
                 # transform events into numpy ndarray
                 # TODO: at this point we should save the order of our input variables
                 #       to ensure that they will be loaded in the correct order when
                 #       doing the evaluation
                 events = events[self.input_features_namespace]
+                logger.debug(f"  Using features: {list(events.fields)}")
+
                 events = ak.to_numpy(events)
                 events = events.astype(
                     [(name, np.float32) for name in events.dtype.names],
@@ -289,35 +321,52 @@ class TTbarSimpleDNN(MLModel):
                 ).view(np.float32).reshape((-1, len(events.dtype)))
 
                 if np.any(~np.isfinite(events)):
-                    raise Exception(f"Non-finite values found in inputs from dataset {dataset}")
+                    raise Exception(f"Non-finite values found in inputs from dataset {dataset}, file {file_idx}")
+
+                logger.debug(f"  Input array shape: {events.shape}")
 
                 # create the truth values for the output layer
                 target = np.zeros((len(events), len(self.processes)))
                 target[:, this_proc_idx] = 1
+                logger.debug(f"  Target array shape: {target.shape}, process index: {this_proc_idx}")
 
                 if np.any(~np.isfinite(target)):
-                    raise Exception(f"Non-finite values found in target from dataset {dataset}")
+                    raise Exception(f"Non-finite values found in target from dataset {dataset}, file {file_idx}")
 
                 if DNN_inputs["weights"] is None:
+                    logger.info("  Initializing DNN input arrays")
                     DNN_inputs["weights"] = weights
                     DNN_inputs["inputs"] = events
                     DNN_inputs["target"] = target
                 else:
+                    logger.debug("  Concatenating to existing DNN input arrays")
                     DNN_inputs["weights"] = np.concatenate([DNN_inputs["weights"], weights])
                     DNN_inputs["inputs"] = np.concatenate([DNN_inputs["inputs"], events])
                     DNN_inputs["target"] = np.concatenate([DNN_inputs["target"], target])
+
+        logger.info("Final NN weights per process:")
+        for proc_name, weight_sum in sum_nnweights_processes.items():
+            logger.info(f"  {proc_name}: {weight_sum:.2f}")
 
         #
         # shuffle events and split into train and validation part
         #
 
-        inputs_size = sum([arr.size * arr.itemsize for arr in DNN_inputs.values()])
-        logger.info(f"inputs size is {inputs_size / 1024**3} GB")
+        total_events = len(DNN_inputs["weights"])
+        logger.info(f"Total events for training: {total_events}")
 
+        inputs_size = sum([arr.size * arr.itemsize for arr in DNN_inputs.values()])
+        logger.info(f"Total input size: {inputs_size / 1024**3:.2f} GB")
+
+        logger.info("Shuffling events...")
         shuffle_indices = np.array(range(len(DNN_inputs["weights"])))
         np.random.shuffle(shuffle_indices)
 
         n_validation_events = int(self.validation_fraction * len(DNN_inputs["weights"]))
+        n_training_events = len(DNN_inputs["weights"]) - n_validation_events
+
+        logger.info(f"Splitting into {n_training_events} training and {n_validation_events} validation events")
+        logger.info(f"Validation fraction: {self.validation_fraction}")
 
         train, validation = {}, {}
         for k in DNN_inputs.keys():
@@ -325,6 +374,10 @@ class TTbarSimpleDNN(MLModel):
 
             validation[k] = DNN_inputs[k][:n_validation_events]
             train[k] = DNN_inputs[k][n_validation_events:]
+
+        logger.info("Input preparation completed successfully")
+        logger.info(f"Training set shapes: inputs={train['inputs'].shape}, weights={train['weights'].shape}, target={train['target'].shape}")
+        logger.info(f"Validation set shapes: inputs={validation['inputs'].shape}, weights={validation['weights'].shape}, target={validation['target'].shape}")
 
         return train, validation
 
@@ -337,67 +390,91 @@ class TTbarSimpleDNN(MLModel):
         """
         Train the model.
         """
+        logger.info("=" * 50)
+        logger.info("STARTING NEURAL NETWORK TRAINING")
+        logger.info("=" * 50)
+
         #
         # TF settings
         #
 
+        logger.info("Setting up TensorFlow...")
+
         # run on GPU
         gpus = tf.config.list_physical_devices("GPU")
+        logger.info(f"Available GPUs: {len(gpus)}")
+        for i, gpu in enumerate(gpus):
+            logger.info(f"  GPU {i}: {gpu}")
 
         # restrict to run only on first GPU
         # https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth
         try:
             tf.config.experimental.set_memory_growth(gpus[0], True)
+            logger.info("GPU memory growth enabled")
         except RuntimeError as e:
             # GPU already initialized -> print warning and continue
-            print(e)
+            logger.warning(f"GPU memory growth setting failed: {e}")
         except IndexError:
-            print("No GPUs found. Will use CPU.")
+            logger.warning("No GPUs found. Will use CPU.")
 
         #
         # prepare input
         #
 
-        # TODO: implement
+        logger.info("Preparing training inputs...")
         train, validation = self.prepare_inputs(task, input)
 
         # check for non-finite values (inf, nan)
+        logger.info("Checking for non-finite values in training data...")
         for key in train.keys():
             if np.any(~np.isfinite(train[key])):
                 raise Exception(f"Non-finite values found in training {key}")
             if np.any(~np.isfinite(validation[key])):
                 raise Exception(f"Non-finite values found in validation {key}")
+        logger.info("Data validation passed - no non-finite values found")
 
         #
         # prepare model
         #
 
-        # TODO: implement
+        logger.info("Building neural network model...")
+
         n_inputs = len(self.input_features)
         n_outputs = len(self.processes)
+
+        logger.info("Network architecture:")
+        logger.info(f"  Input features: {n_inputs}")
+        logger.info(f"  Hidden layers: {self.layers}")
+        logger.info(f"  Output nodes: {n_outputs} (processes: {self.processes})")
+        logger.info(f"  Dropout rate: {self.dropout}")
+        logger.info(f"  Learning rate: {self.learning_rate}")
 
         # start model definition
         model = keras.Sequential()
 
         # define input normalization
         model.add(keras.layers.BatchNormalization(input_shape=(n_inputs,)))
+        logger.info("  Added batch normalization layer")
 
         # hidden layers
-        for n_nodes in self.layers:
+        for i, n_nodes in enumerate(self.layers):
             model.add(keras.layers.Dense(
                 units=n_nodes,
-                activation="ReLU",
+                activation="relu",
             ))
+            logger.info(f"  Added dense layer {i+1}: {n_nodes} nodes")
 
             # optional dropout after each hidden layer
             if self.dropout:
                 model.add(keras.layers.Dropout(self.dropout))
+                logger.info(f"  Added dropout layer: {self.dropout}")
 
         # output layer
         model.add(keras.layers.Dense(
             n_outputs,
             activation="softmax",
         ))
+        logger.info(f"  Added output layer: {n_outputs} nodes with softmax activation")
 
         # optimizer
         # settings from https://github.com/jabuschh/ZprimeClassifier/blob/8c3a8eee/Training.py#L93  # noqa
@@ -407,6 +484,7 @@ class TTbarSimpleDNN(MLModel):
             epsilon=1e-6,
             amsgrad=False,
         )
+        logger.info("Created Adam optimizer")
 
         # compile model
         model.compile(
@@ -414,10 +492,17 @@ class TTbarSimpleDNN(MLModel):
             optimizer=optimizer,
             weighted_metrics=["categorical_accuracy"],
         )
+        logger.info("Model compiled successfully")
+
+        # Print model summary
+        logger.info("Model summary:")
+        model.summary(print_fn=lambda x: logger.info(x))
 
         #
         # training
         #
+
+        logger.info("Setting up training callbacks...")
 
         # early stopping criteria
         early_stopping = keras.callbacks.EarlyStopping(
@@ -433,6 +518,7 @@ class TTbarSimpleDNN(MLModel):
             verbose=0,
             restore_best_weights=True,
         )
+        logger.info(f"  Early stopping: patience={max(1, int(self.epochs / 4))}, min_delta=0.005")
 
         # learning rate reduction on plateau
         lr_reducer = keras.callbacks.ReduceLROnPlateau(
@@ -446,20 +532,29 @@ class TTbarSimpleDNN(MLModel):
             # wait this many epochs w/o improvement before reducing LR
             patience=max(1, int(self.epochs / 8)),  # 100
         )
+        logger.info(f"  LR reduction: patience={max(1, int(self.epochs / 8))}, factor=0.5")
 
+        logger.info("Creating TensorFlow datasets...")
         # construct TF datasets
         with tf.device("CPU"):
             # training
             tf_train = tf.data.Dataset.from_tensor_slices(
                 (train["inputs"], train["target"], train["weights"]),
             ).batch(self.batchsize)
+            logger.info(f"  Training dataset: batch size {self.batchsize}")
 
             # validation
             tf_validate = tf.data.Dataset.from_tensor_slices(
                 (validation["inputs"], validation["target"], validation["weights"]),
             ).batch(self.batchsize)
+            logger.info(f"  Validation dataset: batch size {self.batchsize}")
 
         # do training
+        logger.info("=" * 30)
+        logger.info("STARTING TRAINING")
+        logger.info("=" * 30)
+        logger.info(f"Training for {self.epochs} epochs...")
+
         model.fit(
             tf_train,
             validation_data=tf_validate,
@@ -468,11 +563,21 @@ class TTbarSimpleDNN(MLModel):
             verbose=2,
         )
 
+        logger.info("Training completed")
+
         # save trained model and history
+        logger.info(f"Saving model to {output.path}")
         output.parent.touch()
-        model.save(output.path)
-        with open(f"{output.path}/model_history.pkl", "wb") as f:
+        model.save(f"{output.path}.keras")
+
+        logger.info("Saving training history")
+        with open(f"{output.path}_model_history.pickle", "wb") as f:
             pickle.dump(model.history.history, f)
+
+        logger.info("Model and history saved successfully")
+        logger.info("=" * 50)
+        logger.info("TRAINING COMPLETED")
+        logger.info("=" * 50)
 
     def evaluate(
         self,
@@ -485,20 +590,36 @@ class TTbarSimpleDNN(MLModel):
         """
         Evaluate the model on *events* and return them.
         """
+        logger.info("=" * 50)
+        logger.info("STARTING MODEL EVALUATION")
+        logger.info("=" * 50)
+        
+        logger.info(f"Evaluating on {len(events)} events")
+        logger.info(f"Number of models (folds): {len(models)}")
+        logger.info(f"Events used in training: {events_used_in_training}")
 
         # unpack models and history
         models, history = zip(*models)
+        logger.info("Models and history unpacked")
 
         # create a copy of the inputs to use for evaluation
+        logger.info("Creating copy of input events...")
         inputs = ak.copy(events)
 
         # remove columns not used in training
+        logger.info("Removing unused input features...")
         input_features = inputs[self.input_features_namespace]
+        logger.info(f"Available features: {list(input_features.fields)}")
+        
         for var in input_features.fields:
             if var not in self.input_features:
                 inputs = remove_ak_column(inputs, f"{self.input_features_namespace}.{var}")
+                logger.debug(f"  Removed unused feature: {var}")
+
+        logger.info(f"Using {len(self.input_features)} features: {self.input_features}")
 
         # transform inputs into numpy ndarray
+        logger.info("Converting inputs to numpy array...")
         inputs = inputs[self.input_features_namespace]
         inputs = ak.to_numpy(inputs)
         inputs = inputs.astype(
@@ -506,21 +627,35 @@ class TTbarSimpleDNN(MLModel):
             copy=False,
         ).view(np.float32).reshape((-1, len(inputs.dtype)))
 
+        logger.info(f"Input array shape: {inputs.shape}")
+
         # do prediction for all models and all inputs
+        logger.info("Running predictions with all models...")
         predictions = []
         for i, model in enumerate(models):
+            logger.info(f"  Running prediction with model {i+1}/{len(models)}")
             prediction = ak.from_numpy(model.predict_on_batch(inputs))
+            
             if len(prediction[0]) != len(self.processes):
                 raise Exception("Number of output nodes should be equal to number of processes")
+                
+            logger.info(f"  Model {i+1} prediction shape: {prediction.layout.form}")
             predictions.append(prediction)
 
+        logger.info("All model predictions completed")
+
         # choose prediction from model that has not used the test dataset/fold
-        #outputs = ak.where(ak.ones_like(predictions[0]), -1, -1)  # noqa
+        logger.info("Selecting predictions based on fold indices...")
         outputs = ak.ones_like(predictions[0]) * -1
+        
         for i in range(self.folds):
+            fold_mask = fold_indices == i
+            n_events_in_fold = ak.sum(fold_mask)
+            logger.info(f"  Fold {i}: {n_events_in_fold} events")
+            
             # reshape mask from N*bool to N*k*bool (TODO: simpler way?)
             idx = ak.to_regular(
-                ak.concatenate(
+                ak_concatenate_safe(
                     [
                         ak.singletons(fold_indices == i),
                     ] * len(self.processes),
@@ -536,58 +671,90 @@ class TTbarSimpleDNN(MLModel):
                 f"equal to number of processes ({len(self.processes)}).",
             )
 
+        logger.info(f"Final output shape: {outputs.layout.form}")
+
         # write output scores to columns
+        logger.info("Writing output scores to event columns...")
         for i, proc in enumerate(self.processes):
+            score_values = outputs[:, i]
+            logger.info(f"  Process {proc}: score range [{ak.min(score_values):.4f}, {ak.max(score_values):.4f}]")
             events = set_ak_column(
-                events, f"{self.cls_name}.score_{proc}", outputs[:, i],
+                events, f"{self.cls_name}.score_{proc}", score_values,
             )
 
         #
         # compute categories
         #
 
+        logger.info("Computing ML-based categories...")
+        
         # ML categorization on top of existing categories
         ml_categories = [cat for cat in self.config_inst.categories if "dnn_" in cat.name]
         ml_proc_to_id = {cat.name.replace("dnn_", ""): cat.id for cat in ml_categories}
+        
+        logger.info(f"Available ML categories: {len(ml_categories)}")
+        for cat_name, cat_id in ml_proc_to_id.items():
+            logger.info(f"  {cat_name}: category ID {cat_id}")
 
         # convenience array with all ML scores
         scores = ak.Array({
             f.replace("score_", ""): events[self.cls_name, f]
             for f in events[self.cls_name].fields if f.startswith("score_")
         })
+        
+        logger.info(f"Score fields: {list(scores.fields)}")
 
         # compute max score per event and corresponding category
+        logger.info("Computing maximum scores and corresponding categories...")
         ml_category_id = ak.Array(np.zeros(len(events)))
         max_score = ak.Array(np.zeros(len(events)))
+        
         for proc in scores.fields:
             larger_score = (scores[proc] > max_score)
+            n_better = ak.sum(larger_score)
+            logger.info(f"  Process {proc}: {n_better} events have this as max score")
+            
             ml_category_id = ak.where(larger_score, ml_proc_to_id[proc], ml_category_id)
             max_score = ak.where(larger_score, scores[proc], max_score)
 
+        logger.info(f"Max score range: [{ak.min(max_score):.4f}, {ak.max(max_score):.4f}]")
+
         # overwrite `category_ids` to include the ML category
-        # --
-        # NOTE: this simply adds the ML category ID (an integer) to the ones already present
-        # in the inputs (except the inclusive category, which is left as-is). For this to
-        # produce the expected results, the ML categories need to follow the naming scheme
-        # described under `mtt.config.categories`, which ensures that
-        #     `cat_id_with_ml == cat_id_without_ml + cat_id_ml`
+        logger.info("Updating category IDs with ML categories...")
+        original_categories = ak.unique(events.category_ids)
+        logger.info(f"Original category IDs: {original_categories}")
+        
         category_ids = ak.where(
             events.category_ids != 0,  # do not split inclusive category into DNN sub-categories
             events.category_ids + ak.values_astype(ml_category_id, np.int32),
             events.category_ids,
         )
+        
+        new_categories = ak.unique(category_ids)
+        logger.info(f"New category IDs: {new_categories}")
+        
         events = set_ak_column(events, "category_ids", category_ids)
 
         # sanity check that the produced category IDs are all valid leaf categories
+        logger.info("Validating produced category IDs...")
         leaf_category_ids = {c.id for c in self.config_inst.get_leaf_categories()}
         present_category_ids = set(ak.ravel(events.category_ids))
         invalid_categories = present_category_ids - leaf_category_ids
+        
+        logger.info(f"Valid leaf category IDs: {sorted(leaf_category_ids)}")
+        logger.info(f"Present category IDs: {sorted(present_category_ids)}")
+        
         if invalid_categories:
             invalid_categories = ", ".join(sorted(invalid_categories))
             raise RuntimeError(
                 f"ML evaluation produced category ids that are not defined as valid "
                 f"leaf categories in the config: {invalid_categories}",
             )
+            
+        logger.info("Category validation passed")
+        logger.info("=" * 50)
+        logger.info("MODEL EVALUATION COMPLETED")
+        logger.info("=" * 50)
 
         return events
 
@@ -596,9 +763,10 @@ class TTbarSimpleDNN(MLModel):
 simple_dnn = TTbarSimpleDNN.derive("simple", cls_dict={
 
     # hyperparameters
-    "batchsize": 32768,
+    # "batchsize": 32768,
+    "batchsize": 4096,  # reasonable for training on CPU?
     "dropout": 0.5,
-    "epochs": 500,  # 20/500
+    "epochs": 20,  # 20/500
     "eqweight": True,  # False?
     "folds": 5,  # 2/5
     "layers": [512, 512],
@@ -610,7 +778,7 @@ simple_dnn = TTbarSimpleDNN.derive("simple", cls_dict={
         "tt": 1,
         "st": 1,
         "w_lnu": 1,
-        "dy_lep": 1,
+        "dy": 1,
     },
 
     # processes used for training
@@ -618,40 +786,70 @@ simple_dnn = TTbarSimpleDNN.derive("simple", cls_dict={
         "tt",
         "st",
         "w_lnu",
-        "dy_lep",
+        "dy",
     ],
 
     # datasets used for training
     "dataset_names": {
+        # # Run 2 datasets
+        # # TTbar
+        # "tt_sl_powheg",
+        # "tt_dl_powheg",
+        # "tt_fh_powheg",
+        # # SingleTop
+        # "st_tchannel_t_4f_powheg",
+        # "st_tchannel_tbar_4f_powheg",
+        # "st_twchannel_t_powheg",
+        # "st_twchannel_tbar_powheg",
+        # "st_schannel_lep_4f_amcatnlo",
+        # "st_schannel_had_4f_amcatnlo",
+        # # WJets
+        # "w_lnu_ht70To100_madgraph",
+        # "w_lnu_ht100To200_madgraph",
+        # "w_lnu_ht200To400_madgraph",
+        # "w_lnu_ht400To600_madgraph",
+        # "w_lnu_ht600To800_madgraph",
+        # "w_lnu_ht800To1200_madgraph",
+        # "w_lnu_ht1200To2500_madgraph",
+        # "w_lnu_ht2500_madgraph",
+        # # DY
+        # "dy_lep_m50_ht70to100_madgraph",
+        # "dy_lep_m50_ht100to200_madgraph",
+        # "dy_lep_m50_ht200to400_madgraph",
+        # "dy_lep_m50_ht400to600_madgraph",
+        # "dy_lep_m50_ht600to800_madgraph",
+        # "dy_lep_m50_ht800to1200_madgraph",
+        # "dy_lep_m50_ht1200to2500_madgraph",
+        # "dy_lep_m50_ht2500_madgraph",
+
+        # Run 3 datasets
         # TTbar
         "tt_sl_powheg",
         "tt_dl_powheg",
         "tt_fh_powheg",
         # SingleTop
-        "st_tchannel_t_4f_powheg",
-        "st_tchannel_tbar_4f_powheg",
-        "st_twchannel_t_powheg",
-        "st_twchannel_tbar_powheg",
-        "st_schannel_lep_4f_amcatnlo",
-        "st_schannel_had_4f_amcatnlo",
+        # "st_tchannel_t_4f_powheg",
+        # "st_tchannel_tbar_4f_powheg",
+        "st_twchannel_t_sl_powheg",
+        "st_twchannel_tbar_sl_powheg",
+        "st_twchannel_t_dl_powheg",
+        # "st_twchannel_tbar_dl_powheg",
+        "st_twchannel_t_fh_powheg",
+        "st_twchannel_tbar_fh_powheg",
         # WJets
-        "w_lnu_ht70To100_madgraph",
-        "w_lnu_ht100To200_madgraph",
-        "w_lnu_ht200To400_madgraph",
-        "w_lnu_ht400To600_madgraph",
-        "w_lnu_ht600To800_madgraph",
-        "w_lnu_ht800To1200_madgraph",
-        "w_lnu_ht1200To2500_madgraph",
-        "w_lnu_ht2500_madgraph",
+        "w_lnu_1j_madgraph",
+        "w_lnu_2j_madgraph",
+        "w_lnu_3j_madgraph",
+        "w_lnu_4j_madgraph",
         # DY
-        "dy_lep_m50_ht70to100_madgraph",
-        "dy_lep_m50_ht100to200_madgraph",
-        "dy_lep_m50_ht200to400_madgraph",
-        "dy_lep_m50_ht400to600_madgraph",
-        "dy_lep_m50_ht600to800_madgraph",
-        "dy_lep_m50_ht800to1200_madgraph",
-        "dy_lep_m50_ht1200to2500_madgraph",
-        "dy_lep_m50_ht2500_madgraph",
+        "dy_4j_mumu_m50toinf_madgraph",
+        "dy_4j_ee_m50toinf_madgraph",
+        # "dy_4j_tautau_m50toinf_madgraph",
+        # # VV
+        # # to be added?
+        # "ww_pythia",
+        # "wz_pythia",
+        # "zz_pythia",
     },
 
     # ML inputs
@@ -660,7 +858,7 @@ simple_dnn = TTbarSimpleDNN.derive("simple", cls_dict={
         "n_fatjet",
     ] + [
         f"jet_{var}_{i + 1}"
-        for var in ("energy", "pt", "eta", "phi", "mass", "btag")
+        for var in ("energy", "pt", "eta", "phi", "mass", "btagUParTAK4B")
         for i in range(5)
     ] + [
         f"fatjet_{var}_{i + 1}"

--- a/mtt/production/features.py
+++ b/mtt/production/features.py
@@ -137,7 +137,7 @@ def jet_lepton_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     },
 )
 def features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
-    """All high-level featues, e.g. scalar jet pt sum (ht), number of jets, electrons, muons, etc."""
+    """All high-level features, e.g. scalar jet pt sum (ht), number of jets, electrons, muons, etc."""
 
     # note: the missing Lorentz vector columns cause issues for
     # arrays with registered names/behaviors, so we remove them

--- a/mtt/production/ttbar_reco.py
+++ b/mtt/production/ttbar_reco.py
@@ -301,7 +301,7 @@ def ttbar(
         elif regime == "boosted":
             assert len(n_jets) == 1, (
                 f"`n_jets` must have length 1 (lep) "
-                f"for resolved regime, got {len(n_jets)}"
+                f"for boosted regime, got {len(n_jets)}"
             )
             is_boosted_regime = True
             n_jet_lep = n_jets[0]
@@ -701,6 +701,7 @@ def ttbar(
             gen_ttbar.w_1,
         )]
         gen_ttbar_lv = lv_mass(gen_top_had) + lv_mass(gen_top_lep)
+        gen_ttbar_unmatched = lv_mass(gen_top_1) + lv_mass(gen_top_2)
 
         # -- calculate gen-level cos(theta*)
 
@@ -730,6 +731,9 @@ def ttbar(
         events = set_ak_column_ef(events, "TTbar.gen_delta_r", dr_gen_ttbar)
         events = set_ak_column_ef(events, "TTbar.gen_cos_theta_star", gen_cos_theta_star)
         events = set_ak_column_ef(events, "TTbar.gen_abs_cos_theta_star", gen_abs_cos_theta_star)
+
+        events = set_ak_column_ef(events, "GenTTbar.ttbar_mass", gen_ttbar_unmatched.mass)
+        events = set_ak_column_ef(events, "GenTTbar.mass_diff", gen_ttbar_unmatched.mass - gen_ttbar_lv.mass)
 
     # recalculate category ids with ttbar information in extra producer
 

--- a/mtt/production/util.py
+++ b/mtt/production/util.py
@@ -8,6 +8,7 @@ import itertools
 from functools import partial
 
 from columnflow.util import maybe_import
+from columnflow.production.util import _lv_base
 
 ak = maybe_import("awkward")
 np = maybe_import("numpy")
@@ -155,7 +156,7 @@ def ak_arg_grouped_combinations(
 # functions for operating on lorentz vectors
 #
 
-_lv_base = partial(ak_extract_fields, behavior=coffea.nanoevents.methods.nanoaod.behavior)
+# _lv_base = partial(ak_extract_fields, behavior=coffea.nanoevents.methods.nanoaod.behavior)  # broken (14.10.25)
 
 lv_xyzt = partial(_lv_base, fields=["x", "y", "z", "t"], with_name="LorentzVector")
 lv_xyzt.__doc__ = """Construct a `LorentzVectorArray` from an input array."""

--- a/mtt/selection/default.py
+++ b/mtt/selection/default.py
@@ -15,6 +15,7 @@ from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.selection.stats import increment_stats
 from columnflow.selection.cms.met_filters import met_filters
 from columnflow.selection.cms.json_filter import json_filter
+from columnflow.selection.cms.jets import jet_veto_map
 from columnflow.production.categories import category_ids
 from columnflow.production.cms.mc_weight import mc_weight
 from columnflow.production.processes import process_ids
@@ -49,6 +50,7 @@ ak = maybe_import("awkward")
         # gen_parton_top,
         # gen_v_boson,
         json_filter,
+        jet_veto_map
     },
     produces={
         jet_selection, lepton_selection, met_selection, top_tagged_jets, lepton_jet_2d_selection,
@@ -62,6 +64,7 @@ ak = maybe_import("awkward")
         # gen_parton_top,
         # gen_v_boson,
         json_filter,
+        jet_veto_map
     },
     shifts={
         jet_energy_shifts,
@@ -112,6 +115,10 @@ def default(
     # all-hadronic veto
     events, top_tagged_jets_results = self[top_tagged_jets](events, **kwargs)
     results += top_tagged_jets_results
+
+    # apply jet veto map
+    events, jet_veto_results = self[jet_veto_map](events, **kwargs)
+    results += jet_veto_results
 
     if self.dataset_inst.has_tag("is_qcd"):
         events, qcd_sel_results = self[qcd_spikes](events, **kwargs)

--- a/workflow_scripts/test_workflow.sh
+++ b/workflow_scripts/test_workflow.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
 # set parameters
-datasets=(tt_sl_powheg st_tchannel_t_4f_powheg dy_m4to50_ht800to1500_madgraph ww_pythia w_lnu_mlnu0to120_ht800to1500_madgraph qcd_ht1000to1200_madgraph data_mu_c)
+# datasets=(tt_sl_powheg st_tchannel_t_4f_powheg dy_m4to50_ht800to1500_madgraph ww_pythia w_lnu_mlnu0to120_ht800to1500_madgraph qcd_ht1000to1200_madgraph data_mu_c)
+datasets=(tt_sl_powheg)
 datasets_mc=(tt_sl_powheg st_tchannel_t_4f_powheg dy_m4to50_ht800to1500_madgraph ww_pythia w_lnu_mlnu0to120_ht800to1500_madgraph qcd_ht1000to1200_madgraph)
 
-version=test_updates_250417
-analysis=mtt.config.run3.analysis_mtt.analysis_mtt
-config=run3_mtt_2022_preEE_nano_v12_limited
+version=test_updates_251013_v2
+analysis=mtt.config.run3.analysis_mtt.analysis_mtt_new
+config=run3_mtt_2024_nano_v15_limited_new
 calibrator=skip_jecunc
 selector=default
 reducer=default
@@ -23,8 +24,10 @@ for dataset in "${datasets[@]}"; do
     --analysis $analysis \
     --config $config \
     --dataset $dataset \
-    --calibrator $calibrator
-    echo law run cf.SelectEvents \
+    --workflow local \
+    --calibrator $calibrator \
+    --remove-output 0,a,y
+    law run cf.SelectEvents \
     --version $version \
     --analysis $analysis \
     --config $config \
@@ -111,7 +114,7 @@ echo law run cf.CreateYieldTable \
 #     --datasets $datasets_str \
 
 # plot pt of muon and electron in 1e and 1m - normalized
-law run cf.PlotVariables1D \
+echo law run cf.PlotVariables1D \
     --version $version \
     --analysis $analysis \
     --config $config \


### PR DESCRIPTION
This PR includes various changes and fixes, with the goal of having a working 2024 setup. Other campaigns (aka configs for 22/23 eras) are currently not completely implemented and won't work at this moment and are therefor commented out.

The results with version `251209_v5`/`251209_v5_test` are produced with this setup, and the `simple` ML Model is in a functional state, meaning it works technically. Currently, it only runs on CPU, and also stops training after a few (~5 epochs), probably due to low loss (to be investigated).

The next improvement is to adapt the ML setup from the hbw analysis in order to have a more sophisticated setup in general and to produce diagnostic plots during the training. A new branch will be opened for that.