### PR TITLE
Fix b tagging SF, lepton SF, jerc and other small changes

### DIFF
--- a/merge_btv_corrections.py
+++ b/merge_btv_corrections.py
@@ -1,0 +1,242 @@
+# coding: utf-8
+
+"""
+Tool for merging BTV correction sets into a single, analysis-application-friendly form.
+Taken from Marcel Rieger.
+
+Example output file:
+/afs/cern.ch/work/m/mrieger/public/hbt/external_files/custom_btv_files/btag_merged_2024.json.gz
+Created with:
+/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-01-30/btagging_preliminary.json.gz
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import gzip
+import tempfile
+import copy
+from typing import Generator, Literal
+
+import correctionlib.schemav2
+
+
+def merge_btv_corrections(
+    input_path: str | pathlib.Path,
+    output_path: str | pathlib.Path,
+) -> None:
+    """
+    Example implementation to merge BTV specific corrections applying to different flavors into a single correction
+    that accepts multiple flavors. The strategy is somewhat opinionated for now but could be easily extended for more
+    generic merging scenarios. The case handled here uses the b and light correction sets in [1] with additional info
+    given in [2-4] about handling of c jets and their uncertainties.
+
+    - [1] https://cms-analysis-corrections.docs.cern.ch/corrections_era/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/BTV/2026-01-30/#btagging_preliminaryjsongz  # noqa
+    - [2] https://btv-wiki.docs.cern.ch/PerformanceCalibration/fixedWPSFRecommendations
+    - [3] https://btv-wiki.docs.cern.ch/PerformanceCalibration/SFUncertaintiesAndCorrelations
+    - [4] https://cms-talk.web.cern.ch/t/2024-b-tagging-shape-sfs/141685
+
+    For more info, see `_merge_btv_corrections_inplace` below.
+    """
+    # check input
+    input_path = os.path.abspath(os.path.expandvars(os.path.expanduser(str(input_path))))
+    if not os.path.isfile(input_path):
+        raise FileNotFoundError(f"input file not existing or not a file: {input_path}")
+
+    # prepare output
+    output_path = os.path.abspath(os.path.expandvars(os.path.expanduser(str(output_path))))
+    if os.path.isfile(output_path):
+        os.remove(output_path)
+    else:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    # read the corrections to merge
+    if input_path.endswith(".gz"):
+        with tempfile.NamedTemporaryFile(suffix=".json") as tmp_file:
+            with gzip.open(input_path, "rt") as f_in:
+                tmp_file.write(f_in.read().encode())
+            cset = correctionlib.schemav2.CorrectionSet.parse_file(tmp_file.name)
+    else:
+        cset = correctionlib.schemav2.CorrectionSet.parse_file(input_path)
+
+    # perform the actual merging inplace
+    _merge_btv_corrections_inplace(cset)
+
+    # write them back to file
+    if output_path.endswith(".gz"):
+        with gzip.open(output_path, "wt") as f:
+            f.write(cset.model_dump_json(exclude_unset=True))
+    else:
+        with open(output_path, "w") as f:
+            f.write(cset.model_dump_json(exclude_unset=True))
+
+
+def _merge_btv_corrections_inplace(
+    cset: correctionlib.schemav2.CorrectionSet,
+) -> None:
+    """
+    Implementation of the merging strategy.
+
+    Input and output correction structure:
+    correction
+    └─ systematic
+       └─ working_point
+          └─ flavor
+             └─ abseta
+                └─ pt
+                   └─ values
+
+    Merging strategy:
+    1) load b and light corrections
+    2) append suffixes to systematic names of all b and light corrections to reflect their scope (as in ref. [3])
+    3) for every systematic variation that only applies to light jets, register a copy of the central values of b/c jets
+       with the name of the light variation and vice versa, allowing for simple evaluation on analysis-level
+    4) create c correction
+       - start with copy of b
+       - change flavor node values to 4 in all systematic variations
+       - double uncertainties w.r.t. the central one in all systematic variations
+    5) merge b, c and light corrections
+       - start with copy of b
+       - merge with c under working_point nodes
+       - merge with light under working_point nodes, which is trivial as per step 3)
+    """
+    # 1) get b and light corrections
+    b_corr = copy.deepcopy(_get_correction(cset, "UParTAK4_kinfit"))
+    l_corr = copy.deepcopy(_get_correction(cset, "UParTAK4_negtagDY"))
+
+    # 2) amend systematic names with suffixes, store central ones for 3)
+    b_syst_item_central = None
+    l_syst_item_central = None
+    for b_syst_item in _iter_btv_correction(b_corr, stop="systematic"):
+        if b_syst_item.key != "central":
+            b_syst_item.key += "_bc"
+        else:
+            b_syst_item_central = b_syst_item
+    for l_syst_item in _iter_btv_correction(l_corr, stop="systematic"):
+        if l_syst_item.key != "central":
+            l_syst_item.key += "_light"
+        else:
+            l_syst_item_central = l_syst_item
+
+    # 3) duplicate non-central variations from b to light with central values and vice versa
+    for b_syst_item in _iter_btv_correction(b_corr, stop="systematic"):
+        if b_syst_item.key.endswith("_bc"):
+            l_syst_item = copy.deepcopy(l_syst_item_central)
+            l_syst_item.key = b_syst_item.key
+            l_corr.data.content.append(l_syst_item)
+    for l_syst_item in _iter_btv_correction(l_corr, stop="systematic"):
+        if l_syst_item.key.endswith("_light"):
+            b_syst_item = copy.deepcopy(b_syst_item_central)
+            b_syst_item.key = l_syst_item.key
+            b_corr.data.content.append(b_syst_item)
+
+    # 4) create c correction
+    c_corr = copy.deepcopy(b_corr)
+    central_sf_values = {}
+    for c_syst_item, wp_item, flavor_item, eta_binning, eta_edges, _, sf_values in _iter_btv_correction(c_corr):
+        # overwrite flavor
+        flavor_item.key = 4
+        # save central values during central iteration, or double uncertainty for other systematics
+        central_key = (wp_item.key, eta_edges)
+        if c_syst_item.key == "central":
+            central_sf_values[central_key] = sf_values
+        elif c_syst_item.key.endswith("_bc"):
+            for i, (syst_value, central_value) in enumerate(zip(sf_values, central_sf_values[central_key])):
+                sf_values[i] = 2 * syst_value - central_value
+
+    # 5) merge b, c and light corrections into a single one
+    merged_corr = copy.deepcopy(b_corr)
+    merged_corr.name = "UParTAK4_merged"
+    merged_corr.version = 1
+    merged_corr.description = (
+        f"Scale factors for b, c and light jets. Created by merging the '{b_corr.name}' and '{l_corr.name}' "
+        "corrections, duplicating the b corrections for c jets and doubling their uncertainty. For more info, see the "
+        "description of the respective corrections, especially regarding their systematic variations. Note that, "
+        "systematic variations ending in '_bc' ('_light') only affect flavor 4/5 (0) and evaluate to 'central' values "
+        "otherwise."
+    )
+    # merge with c at working_point level
+    # (pairwise traversal would be faster, but brute-force is perfectly fine to keep it simple)
+    for syst_item, wp_item in _iter_btv_correction(merged_corr, stop="working_point"):
+        for c_syst_item, c_wp_item in _iter_btv_correction(c_corr, stop="working_point"):
+            if (syst_item.key, wp_item.key) == (c_syst_item.key, c_wp_item.key):
+                wp_item.value.content += c_wp_item.value.content
+    # merge with light at working_point level (possible as per 3)
+    for syst_item, wp_item in _iter_btv_correction(merged_corr, stop="working_point"):
+        for l_syst_item, l_wp_item in _iter_btv_correction(l_corr, stop="working_point"):
+            if (syst_item.key, wp_item.key) == (l_syst_item.key, l_wp_item.key):
+                wp_item.value.content += l_wp_item.value.content
+
+    # add back the merged correction
+    cset.corrections.append(merged_corr)
+
+
+def _get_correction(
+    cset: correctionlib.schemav2.CorrectionSet,
+    name: str,
+) -> correctionlib.schemav2.Correction:
+    """
+    Helper to retrieve a correction by *name* from a schema v2 correction set *cset*. Raises a KeyError if not found.
+    """
+    for corr in cset.corrections:
+        if corr.name == name:
+            return corr
+    raise KeyError(f"correction '{name}' not found in correction set '{cset.name}'")
+
+
+def _iter_btv_correction(
+    corr: correctionlib.schemav2.Correction,
+    *,
+    stop: Literal["systematic", "working_point", "flavor"] | None = None,
+) -> Generator[tuple, None, None]:
+    """
+    Iteration helper to loop over all relevant nodes of a typical BTV correction *corr*, yielding the relevant info at
+    each level. The iteration order is guaranteed to be such that the "central" systematic variation is always visited
+    first if existing.
+
+    When a *stop* level is given, the iteration depth is limited to that level and the yielded info only contains nodes
+    up to that level.
+    """
+    # prepare sorted list of syst_items such that "central" is guaranteed to come first
+    syst_items = list(corr.data.content)
+    for i, syst_item in enumerate(syst_items):
+        if syst_item.key == "central":
+            syst_items.insert(0, syst_items.pop(i))
+            break
+
+    # iterate
+    for syst_item in syst_items:
+        if stop == "systematic":
+            yield syst_item
+            continue
+        syst_cat = syst_item.value
+        for wp_item in syst_cat.content:
+            if stop == "working_point":
+                yield (syst_item, wp_item)
+                continue
+            flavor_cat = wp_item.value
+            for flavor_item in flavor_cat.content:
+                if stop == "flavor":
+                    yield (syst_item, wp_item, flavor_item)
+                    continue
+                eta_binning = flavor_item.value
+                for i, pt_binning in enumerate(eta_binning.content):
+                    eta_edges = (eta_binning.edges[i], eta_binning.edges[i + 1])
+                    sf_values = pt_binning.content
+                    yield (syst_item, wp_item, flavor_item, eta_binning, eta_edges, pt_binning, sf_values)
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="merge BTV corrections into a single file")
+    parser.add_argument("input_path", help="path to the input correction file to read")
+    parser.add_argument("output_path", help="path to the output correction file to generate, overwrites existing files")
+    args = parser.parse_args()
+
+    merge_btv_corrections(args.input_path, args.output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/mtt/calibration/default.py
+++ b/mtt/calibration/default.py
@@ -48,7 +48,7 @@ def default(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
         msoftdrop,
         jec_subjets,
         # jer_subjets,
-        met_phi
+        # met_phi
     },
     produces={
         mc_weight,
@@ -58,7 +58,7 @@ def default(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
         msoftdrop,
         jec_subjets,
         # jer_subjets,
-        met_phi
+        # met_phi
     },
 )
 def skip_jecunc(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
@@ -79,7 +79,7 @@ def skip_jecunc(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     #     events = self[jer_subjets](events, **kwargs)
     events = self[msoftdrop](events, **kwargs)
 
-    events = self[met_phi](events, **kwargs)
+    # events = self[met_phi](events, **kwargs)
 
     return events
 

--- a/mtt/calibration/default.py
+++ b/mtt/calibration/default.py
@@ -3,6 +3,7 @@
 """
 Calibration methods.
 """
+import functools
 
 from columnflow.calibration import Calibrator, calibrator
 from columnflow.calibration.cms.jets import jets
@@ -11,11 +12,16 @@ from columnflow.calibration.cms.jets import jets
 # from columnflow.calibration.cms.muon import muon_sr
 from columnflow.production.cms.mc_weight import mc_weight
 from columnflow.production.cms.seeds import deterministic_seeds
+from columnflow.production.cms.jet import msoftdrop
 from columnflow.util import maybe_import
+from columnflow.columnar_util import set_ak_column
 
-from mtt.calibration.jets import jet_energy, jet_lepton_cleaner
+from mtt.calibration.jets import jet_energy, jet_lepton_cleaner, jec_subjets, jer_subjets
 
 ak = maybe_import("awkward")
+np = maybe_import("numpy")
+
+set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 
 
 @calibrator(
@@ -32,8 +38,24 @@ def default(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
 
 
 @calibrator(
-    uses={mc_weight, deterministic_seeds, jet_lepton_cleaner, jet_energy},
-    produces={mc_weight, deterministic_seeds, jet_lepton_cleaner, jet_energy},
+    uses={
+        mc_weight,
+        deterministic_seeds,
+        jet_lepton_cleaner,
+        jet_energy,
+        msoftdrop,
+        jec_subjets,
+        # jer_subjets
+    },
+    produces={
+        mc_weight,
+        deterministic_seeds,
+        jet_lepton_cleaner,
+        jet_energy,
+        msoftdrop,
+        jec_subjets,
+        # jer_subjets
+    },
 )
 def skip_jecunc(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     """ only uses jec_nominal for test purposes """
@@ -42,6 +64,16 @@ def skip_jecunc(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     events = self[deterministic_seeds](events, **kwargs)
     events = self[jet_lepton_cleaner](events, **kwargs)
     events = self[jet_energy](events, **kwargs)
+
+    # fake subjet area column by setting it to an array with the same structure as the subjet pt column containing 0.5
+    # (needed to be able to use same code as for top-level AK4/AK8 jets, as the producer formally requires an `area`
+    # column, despite not actually using it)
+    events = set_ak_column_f32(events, "SubJet.area", 0.5 * ak.ones_like(events.SubJet.pt))
+
+    events = self[jec_subjets](events, **kwargs)
+    # if self.dataset_inst.is_mc:
+    #     events = self[jer_subjets](events, **kwargs)
+    events = self[msoftdrop](events, **kwargs)
 
     return events
 

--- a/mtt/calibration/default.py
+++ b/mtt/calibration/default.py
@@ -7,6 +7,7 @@ import functools
 
 from columnflow.calibration import Calibrator, calibrator
 from columnflow.calibration.cms.jets import jets
+from columnflow.calibration.cms.met import met_phi
 # TODO should we add these later?
 # from columnflow.calibration.cms.egamma import electron_scale_smear
 # from columnflow.calibration.cms.muon import muon_sr
@@ -29,6 +30,7 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
     produces={mc_weight, deterministic_seeds, jets},
 )
 def default(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
+    raise NotImplementedError("This is not a real calibrator, just a placeholder for the default sequence of calibrators to be applied. Please implement the actual calibrator functions and replace this with the correct sequence of calls to those functions.")
     if self.dataset_inst.is_mc:
         events = self[mc_weight](events, **kwargs)
     events = self[deterministic_seeds](events, **kwargs)
@@ -45,7 +47,8 @@ def default(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
         jet_energy,
         msoftdrop,
         jec_subjets,
-        # jer_subjets
+        # jer_subjets,
+        met_phi
     },
     produces={
         mc_weight,
@@ -54,7 +57,8 @@ def default(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
         jet_energy,
         msoftdrop,
         jec_subjets,
-        # jer_subjets
+        # jer_subjets,
+        met_phi
     },
 )
 def skip_jecunc(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
@@ -74,6 +78,8 @@ def skip_jecunc(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     # if self.dataset_inst.is_mc:
     #     events = self[jer_subjets](events, **kwargs)
     events = self[msoftdrop](events, **kwargs)
+
+    events = self[met_phi](events, **kwargs)
 
     return events
 

--- a/mtt/calibration/jets.py
+++ b/mtt/calibration/jets.py
@@ -6,7 +6,7 @@ Custom jet energy calibration methods that disable data uncertainties (for searc
 
 from columnflow.calibration import Calibrator, calibrator
 # from columnflow.calibration.cms.jets import jec, jer
-from columnflow.calibration.cms.jets import jec_ak4, jer_ak4, jec_ak8, jer_ak8
+from columnflow.calibration.cms.jets import jec_ak4, jer_ak4, jec_ak8, jer_ak8, get_jerc_file_default
 from columnflow.util import maybe_import
 from columnflow.production.util import attach_coffea_behavior
 from columnflow.columnar_util import set_ak_column
@@ -55,6 +55,12 @@ jer_ak8_nominal = jer_ak8.derive(
         "raw_met_name": "DO_NOT_USE",
     },
 )
+
+
+get_jerc_file_default.map_jet_name_file_key["SubJet"] = "jet_jerc"
+jer_subjets = jer_ak8_nominal.derive("jer_subjets", cls_dict={"jet_name": "SubJet", "gen_jet_name": "SubGenJetAK8"})
+jec_subjets = jec_ak8_nominal.derive("jec_subjets", cls_dict={"jet_name": "SubJet", "gen_jet_name": "SubGenJetAK8"})
+jec_subjets_nominal = jec_subjets.derive("jec_subjets", cls_dict={"uncertainty_sources": []})
 
 
 @calibrator

--- a/mtt/config/categories.py
+++ b/mtt/config/categories.py
@@ -107,11 +107,38 @@ def add_categories_selection(config: od.Config) -> None:
         label=r"1t",
     )
 
+    # number of jets
+    config.add_category(
+        name="0j",
+        id=10000,
+        selection="sel_0j",
+        label=r"0j",
+    )
+    config.add_category(
+        name="1j",
+        id=20000,
+        selection="sel_1j",
+        label=r"1j",
+    )
+    config.add_category(
+        name="2j",
+        id=30000,
+        selection="sel_2j",
+        label=r"2j",
+    )
+    config.add_category(
+        name="3j",
+        id=40000,
+        selection="sel_3j",
+        label=r">=3j",
+    )
+
     # -- combined categories
 
     category_groups = {
         "lepton": CategoryGroup(["1e", "1m"], is_complete=True, has_overlap=False),
         "n_top_tags": CategoryGroup(["0t", "1t"], is_complete=False, has_overlap=False),
+        "n_jets": CategoryGroup(["0j", "1j", "2j", "3j"], is_complete=True, has_overlap=False),
     }
 
     create_category_combinations(config, category_groups, name_fn, kwargs_fn=kwargs_fn, parent_mode="safe")
@@ -177,6 +204,7 @@ def add_categories_production(config: od.Config) -> None:
     category_groups = {
         "lepton": CategoryGroup(["1e", "1m"], is_complete=True, has_overlap=False),
         "n_top_tags": CategoryGroup(["0t", "1t"], is_complete=False, has_overlap=False),
+        "n_jets": CategoryGroup(["0j", "1j", "2j", "3j"], is_complete=True, has_overlap=False),
         "chi2": CategoryGroup(["chi2pass", "chi2fail"], is_complete=True, has_overlap=False),
         "cos_theta_star": CategoryGroup(
             ["acts_0_5", "acts_5_7", "acts_7_9", "acts_9_1"],

--- a/mtt/config/corrections.py
+++ b/mtt/config/corrections.py
@@ -516,6 +516,7 @@ def lepton_sf_cfg(
     }
 
     if lepton == "electron":
+        lep_selection = config.x.lepton_selection["e"]
         # electron_id_sf_config = ElectronSFConfig(
         #     correction=lepton_sf_dict[run][tag][lepton]["id_sf_names"][0],
         #     campaign=lepton_sf_dict[run][tag][lepton]["id_sf_names"][1],
@@ -525,15 +526,16 @@ def lepton_sf_cfg(
             correction=lepton_sf_dict[run][tag][lepton]["reco_sf_names"][0],
             campaign=lepton_sf_dict[run][tag][lepton]["reco_sf_names"][1],
             working_point={
-                "wp80iso": (lambda variables: variables["pt"] > 10.0),
-                "RecoBelow20": (lambda variables: variables["pt"] < 20.0),
-                "Reco20to75": (lambda variables: (variables["pt"] >= 20.0) & (variables["pt"] < 75.0)),
+                "wp80iso": (lambda variables: (variables["pt"] >= lep_selection["min_pt"]["low_pt"]) & (variables["pt"] < lep_selection["min_pt"]["high_pt"])),
+                "RecoBelow20": (lambda variables: variables["pt"] < lep_selection["min_pt"]["low_pt"]),
+                "Reco20to75": (lambda variables: (variables["pt"] >= lep_selection["min_pt"]["low_pt"]) & (variables["pt"] < 75.0)),
                 "RecoAbove75": (lambda variables: variables["pt"] >= 75.0),
             },
         )
         return electron_reco_id_sf_config
 
     elif lepton == "muon":
+        lep_selection = config.x.lepton_selection["mu"]
         muon_sf_config = MuonSFConfig(
             correction=lepton_sf_dict[run][tag][lepton]["sf_names"][0],
             # campaign=run,
@@ -544,7 +546,8 @@ def lepton_sf_cfg(
         )
         muon_iso_config = MuonSFConfig(
             correction=lepton_sf_dict[run][tag][lepton]["iso_sf_names"][0],
-            # campaign=run,
+            min_pt=lep_selection["min_pt"]["low_pt"],  # isolation requirement only for low pt muons
+            max_pt=lep_selection["min_pt"]["high_pt"],  # isolation requirement only for low pt muons
         )
         return [muon_sf_config, muon_id_config, muon_iso_config]
 

--- a/mtt/config/corrections.py
+++ b/mtt/config/corrections.py
@@ -367,7 +367,7 @@ def btag_sf_cfg(
         btag_wp_count_config = BTagWPCountConfig(
             jet_name="Jet",
             btag_column=discr,
-            btag_wps=config.x.btag_wp_names.UParTAK4,
+            btag_wps=config.x.btag_wp.btagUParTAK4B,
             pt_edges=(0, 20, 30, 50, 70, 100, 140, 200, 300, 600, 10_000),
             # abs_eta_edges=(0.0, 1.0, 1.5, 2.0, 5.0),
             abs_eta_edges=(0.0, 1.5, 5.0),
@@ -391,7 +391,7 @@ def btag_sf_cfg(
             jet_name="Jet",
             btag_column=discr,
             correction_set="UParTAK4_merged",
-            btag_wps=config.x.btag_wp_names.UParTAK4,
+            btag_wps=config.x.btag_wp.btagUParTAK4B,
             dataset_groups=dataset_groups,
             systs=btag_uncs,
             # further merge eta bins for sufficient statistics in each bin

--- a/mtt/config/corrections.py
+++ b/mtt/config/corrections.py
@@ -325,6 +325,39 @@ def btag_sf_cfg(
         "SinglePionHCAL",
         "TimePtEta",
     ]
+
+    btag_uncs = {
+        ## combined(?) uncertainties
+        # uncertainties to b/c jets
+        "down_bc": "bc_down",
+        "up_bc": "bc_up",
+        # uncertainties to light jets
+        "down_light": "light_down",
+        "up_light": "light_up",
+        ## split uncertainties(?) (all needed?)
+        # uncertainties to b/c jets
+        "up_fsrdef_bc": "fsrdef_bc_up",
+        "up_isrdef_bc": "isrdef_bc_up",
+        "up_hdamp_bc": "hdamp_bc_up",
+        "up_jer_bc": "jer_bc_up",
+        "up_jes_bc": "jes_bc_up",
+        "up_mass_bc": "mass_bc_up",
+        "up_statistic_bc": "statistic_bc_up",
+        "up_tune_bc": "tune_bc_up",
+        "down_fsrdef_bc": "fsrdef_bc_down",
+        "down_isrdef_bc": "isrdef_bc_down",
+        "down_hdamp_bc": "hdamp_bc_down",
+        "down_jer_bc": "jer_bc_down",
+        "down_jes_bc": "jes_bc_down",
+        "down_mass_bc": "mass_bc_down",
+        "down_statistic_bc": "statistic_bc_down",
+        "down_tune_bc": "tune_bc_down",
+        # uncertainties to light jets
+        "down_correlated_light": "correlated_light_down",
+        "up_correlated_light": "correlated_light_up",
+        "down_uncorrelated_light": "uncorrelated_light_down",
+        "up_uncorrelated_light": "uncorrelated_light_up",
+    }
     if year == 2024:
         # TODO: use shape based BTagSFConfig when available
         # currently, one fixed WP is available for b tagging SF in 2024
@@ -336,7 +369,8 @@ def btag_sf_cfg(
             btag_column=discr,
             btag_wps=config.x.btag_wp_names.UParTAK4,
             pt_edges=(0, 20, 30, 50, 70, 100, 140, 200, 300, 600, 10_000),
-            abs_eta_edges=(0.0, 1.0, 1.5, 2.0, 5.0),
+            # abs_eta_edges=(0.0, 1.0, 1.5, 2.0, 5.0),
+            abs_eta_edges=(0.0, 1.5, 5.0),
         )
 
         from columnflow.production.cms.btag import BTagWPSFConfig
@@ -355,10 +389,13 @@ def btag_sf_cfg(
 
         btag_wp_sf_config = BTagWPSFConfig(
             jet_name="Jet",
-            btag_column="btagUParTAK4B",
+            btag_column=discr,
             correction_set="UParTAK4_merged",
             btag_wps=config.x.btag_wp_names.UParTAK4,
             dataset_groups=dataset_groups,
+            systs=btag_uncs,
+            # further merge eta bins for sufficient statistics in each bin
+            abs_eta_edges=(0.0, 5.0),
         )
     else:
         raise NotImplementedError("B-tagging SFs for 2022 and 2023 not implemented yet.")

--- a/mtt/config/corrections.py
+++ b/mtt/config/corrections.py
@@ -343,7 +343,7 @@ def btag_sf_cfg(
 
         def dataset_groups(dataset_inst: od.Dataset) -> list[od.Dataset]:
             # check which group the dataset belongs to
-            for group_index in range(1, len(config.x.btag_wp_eff_groups) + 1):
+            for group_index in range(0, len(config.x.btag_wp_eff_groups)):
                 group_tag = f"btag_wp_eff_group_{group_index}"
                 if dataset_inst.has_tag(group_tag):
                     return [

--- a/mtt/config/corrections.py
+++ b/mtt/config/corrections.py
@@ -281,7 +281,8 @@ def jerc_cfg(
 
 
 def btag_sf_cfg(
-        year: int = None,
+    config: od.Config,
+    year: int = None,
 ) -> list[tuple, list]:
     name = ("deepJet_shape") if year != 2024 else ("UParTAK4_kinfit")
     discr = "btagPNetB" if year != 2024 else "btagUParTAK4B"
@@ -324,20 +325,50 @@ def btag_sf_cfg(
         "SinglePionHCAL",
         "TimePtEta",
     ]
-    # if year == 2024:
-    #     systematics = [
-    #         "central",
-    #         # "fsrdef", "hdamp", "isrdef", "jer", "jes", "mass",
-    #         # "statistic", "tune",
-    #     ]
-    btag_sf_config = BTagSFConfig(
-        correction_set=name,
-        jec_sources=jec_sources,
-        discriminator=discr,
-        corrector_kwargs={"working_point": "M", "flavor": 5} if year == 2024 else {"working_point": "medium"},
-    )
+    if year == 2024:
+        # TODO: use shape based BTagSFConfig when available
+        # currently, one fixed WP is available for b tagging SF in 2024
+        # implementation from hbt analysis:
+        # https://github.com/uhh-cms/hh2bbtautau/blob/4b2f1bc57a9c2ada18776e5ac6f0372269e1e26c/hbt/config/configs_hbt.py#L1410 # noqa
+        from columnflow.selection.cms.btag import BTagWPCountConfig
+        btag_wp_count_config = BTagWPCountConfig(
+            jet_name="Jet",
+            btag_column=discr,
+            btag_wps=config.x.btag_wp_names.UParTAK4,
+            pt_edges=(0, 20, 30, 50, 70, 100, 140, 200, 300, 600, 10_000),
+            abs_eta_edges=(0.0, 1.0, 1.5, 2.0, 5.0),
+        )
 
-    return btag_sf_config
+        from columnflow.production.cms.btag import BTagWPSFConfig
+
+        def dataset_groups(dataset_inst: od.Dataset) -> list[od.Dataset]:
+            # check which group the dataset belongs to
+            for group_index in range(1, len(config.x.btag_wp_eff_groups) + 1):
+                group_tag = f"btag_wp_eff_group_{group_index}"
+                if dataset_inst.has_tag(group_tag):
+                    return [
+                        _dataset_inst
+                        for _dataset_inst in config.datasets
+                        if _dataset_inst.has_tag(group_tag)
+                    ]
+            raise NotImplementedError(f"btag WP efficiency group not implemented for dataset {dataset_inst.name}")
+
+        btag_wp_sf_config = BTagWPSFConfig(
+            jet_name="Jet",
+            btag_column="btagUParTAK4B",
+            correction_set="UParTAK4_merged",
+            btag_wps=config.x.btag_wp_names.UParTAK4,
+            dataset_groups=dataset_groups,
+        )
+    else:
+        raise NotImplementedError("B-tagging SFs for 2022 and 2023 not implemented yet.")
+
+    configs = {
+        "btag_wp_count_config": btag_wp_count_config,
+        "btag_wp_sf_config": btag_wp_sf_config,
+    }
+
+    return configs
 
 
 def toptag_sf_cfg(

--- a/mtt/config/corrections.py
+++ b/mtt/config/corrections.py
@@ -516,40 +516,40 @@ def lepton_sf_cfg(
     }
 
     if lepton == "electron":
-        lep_selection = config.x.lepton_selection["e"]
-        # electron_id_sf_config = ElectronSFConfig(
-        #     correction=lepton_sf_dict[run][tag][lepton]["id_sf_names"][0],
-        #     campaign=lepton_sf_dict[run][tag][lepton]["id_sf_names"][1],
-        #     working_point="wp80iso",  # taken from hbt config
-        # )
-        electron_reco_id_sf_config = ElectronSFConfig(
+        electron_id_iso_sf_config = ElectronSFConfig(
             correction=lepton_sf_dict[run][tag][lepton]["reco_sf_names"][0],
             campaign=lepton_sf_dict[run][tag][lepton]["reco_sf_names"][1],
             working_point={
-                "wp80iso": (lambda variables: (variables["pt"] >= lep_selection["min_pt"]["low_pt"]) & (variables["pt"] < lep_selection["min_pt"]["high_pt"])),
-                "RecoBelow20": (lambda variables: variables["pt"] < lep_selection["min_pt"]["low_pt"]),
-                "Reco20to75": (lambda variables: (variables["pt"] >= lep_selection["min_pt"]["low_pt"]) & (variables["pt"] < 75.0)),
+                "wp80iso": (lambda variables: variables["pt"] > 10),
+            },
+        )
+        electron_reco_sf_config = ElectronSFConfig(
+            correction=lepton_sf_dict[run][tag][lepton]["reco_sf_names"][0],
+            campaign=lepton_sf_dict[run][tag][lepton]["reco_sf_names"][1],
+            working_point={
+                "RecoBelow20": (lambda variables: variables["pt"] < 20),
+                "Reco20to75": (lambda variables: (variables["pt"] >= 20) & (variables["pt"] < 75.0)),
                 "RecoAbove75": (lambda variables: variables["pt"] >= 75.0),
             },
         )
-        return electron_reco_id_sf_config
+        configs = {
+            "electron_id_iso_sf_config": electron_id_iso_sf_config,
+            "electron_reco_sf_config": electron_reco_sf_config,
+        }
+        return configs
 
     elif lepton == "muon":
-        lep_selection = config.x.lepton_selection["mu"]
-        muon_sf_config = MuonSFConfig(
-            correction=lepton_sf_dict[run][tag][lepton]["sf_names"][0],
-            # campaign=run,
-        )
         muon_id_config = MuonSFConfig(
             correction=lepton_sf_dict[run][tag][lepton]["id_sf_names"][0],
-            # campaign=run,
         )
         muon_iso_config = MuonSFConfig(
             correction=lepton_sf_dict[run][tag][lepton]["iso_sf_names"][0],
-            min_pt=lep_selection["min_pt"]["low_pt"],  # isolation requirement only for low pt muons
-            max_pt=lep_selection["min_pt"]["high_pt"],  # isolation requirement only for low pt muons
         )
-        return [muon_sf_config, muon_id_config, muon_iso_config]
+        configs = {
+            "muon_id_config": muon_id_config,
+            "muon_iso_config": muon_iso_config,
+        }
+        return configs
 
 
 def met_phi_cfg(

--- a/mtt/config/datasets.py
+++ b/mtt/config/datasets.py
@@ -383,7 +383,7 @@ def st_datasets(
             ],
             "2024": [
                 # t channel
-                # "st_tchannel_t_had_4f_powheg",  # FIXME one broken file stuck at CalibrateEvents?
+                "st_tchannel_t_had_4f_powheg",  # FIXME one broken file stuck at CalibrateEvents?
                 "st_tchannel_tbar_had_4f_powheg",
                 "st_tchannel_t_lep_4f_powheg",
                 "st_tchannel_tbar_lep_4f_powheg",
@@ -464,9 +464,9 @@ def qcd_datasets(
                 "qcd_ht2000toinf_madgraph",
             ],
             "2024": [
-                # "qcd_ht40to70_madgraph",  # FIXME empty after selection (lim. config)
-                # "qcd_ht70to100_madgraph",  # FIXME empty after selection (lim. config)
-                # "qcd_ht100to200_madgraph",  # FIXME empty after selection (lim. config)
+                "qcd_ht40to70_madgraph",  # FIXME empty after selection (lim. config)
+                "qcd_ht70to100_madgraph",  # FIXME empty after selection (lim. config)
+                "qcd_ht100to200_madgraph",  # FIXME empty after selection (lim. config)
                 "qcd_ht200to400_madgraph",
                 "qcd_ht400to600_madgraph",
                 "qcd_ht600to800_madgraph",

--- a/mtt/config/datasets.py
+++ b/mtt/config/datasets.py
@@ -383,7 +383,7 @@ def st_datasets(
             ],
             "2024": [
                 # t channel
-                "st_tchannel_t_had_4f_powheg",  # FIXME one broken file stuck at CalibrateEvents?
+                "st_tchannel_t_had_4f_powheg",
                 "st_tchannel_tbar_had_4f_powheg",
                 "st_tchannel_t_lep_4f_powheg",
                 "st_tchannel_tbar_lep_4f_powheg",
@@ -464,9 +464,9 @@ def qcd_datasets(
                 "qcd_ht2000toinf_madgraph",
             ],
             "2024": [
-                "qcd_ht40to70_madgraph",  # FIXME empty after selection (lim. config)
-                "qcd_ht70to100_madgraph",  # FIXME empty after selection (lim. config)
-                "qcd_ht100to200_madgraph",  # FIXME empty after selection (lim. config)
+                # "qcd_ht40to70_madgraph",  # FIXME empty after selection (both full & lim. config)
+                # "qcd_ht70to100_madgraph",  # FIXME empty after selection (both full & lim. config)
+                # "qcd_ht100to200_madgraph",  # FIXME empty after selection (both full & lim. config)
                 "qcd_ht200to400_madgraph",
                 "qcd_ht400to600_madgraph",
                 "qcd_ht600to800_madgraph",
@@ -579,11 +579,11 @@ def zprime_datasets(
                 "zprime_tt_m4000_w40_madgraph",
                 "zprime_tt_m4500_w45_madgraph",
                 "zprime_tt_m7000_w70_madgraph",
-                # 10% width samples
-                # "zprime_tt_m2000_w200_madgraph",
-                "zprime_tt_m8000_w800_madgraph",
-                # 30% width samples
-                "zprime_tt_m5000_w1500_madgraph",
+                # # 10% width samples
+                # # "zprime_tt_m2000_w200_madgraph",
+                # "zprime_tt_m8000_w800_madgraph",
+                # # 30% width samples
+                # "zprime_tt_m5000_w1500_madgraph",
             ],
         },
     }

--- a/mtt/config/datasets.py
+++ b/mtt/config/datasets.py
@@ -574,16 +574,46 @@ def zprime_datasets(
                 "zprime_tt_m7000_w2100_madgraph",
             ],
             "2024": [
+                # SIGNAL SAMPLES AVAILABLE AS OF 27.02.26
+                # currently only a subset of the full mass-width grid is included in the analysis, the main reason
+                # for that being that the b tagging SF calculation currently relies on a generic string ('zprime_tt*')
+                # to include all available Z' samples. For the final analysis, a smart grouping needs to be implemented
+                # as it probably isn't correct to mix between the different widths samples. It might also be that
+                # we can only include one sample at a time.
+                # Commenting out the samples currently triggers the entire workflow to run for all samples
+                # for the weights producer, so be careful!
                 # 1% width samples
                 "zprime_tt_m500_w5_madgraph",
+                # "zprime_tt_m900_w9_madgraph",
+                # "zprime_tt_m1400_w14_madgraph",
+                # "zprime_tt_m1600_w16_madgraph",
+                # "zprime_tt_m2000_w20_madgraph",
+                # "zprime_tt_m2500_w25_madgraph",
                 "zprime_tt_m4000_w40_madgraph",
                 "zprime_tt_m4500_w45_madgraph",
+                # "zprime_tt_m5000_w50_madgraph",
                 "zprime_tt_m7000_w70_madgraph",
-                # # 10% width samples
-                # # "zprime_tt_m2000_w200_madgraph",
+                # # # 10% width samples
+                # "zprime_tt_m500_w50_madgraph",
+                # "zprime_tt_m600_w60_madgraph",
+                # "zprime_tt_m1200_w120_madgraph",
+                # "zprime_tt_m1600_w160_madgraph",
+                # "zprime_tt_m1800_w180_madgraph",
+                # "zprime_tt_m2000_w200_madgraph",
+                # "zprime_tt_m2500_w250_madgraph",
+                # "zprime_tt_m5000_w500_madgraph",
+                # "zprime_tt_m6000_w600_madgraph",
+                # "zprime_tt_m7000_w700_madgraph",
                 # "zprime_tt_m8000_w800_madgraph",
                 # # 30% width samples
+                # "zprime_tt_m400_w120_madgraph",
+                # "zprime_tt_m800_w240_madgraph",
+                # "zprime_tt_m900_w270_madgraph",
+                # "zprime_tt_m1000_w300_madgraph",
+                # "zprime_tt_m2000_w600_madgraph",
+                # "zprime_tt_m3500_w1050_madgraph",
                 # "zprime_tt_m5000_w1500_madgraph",
+                # "zprime_tt_m6000_w1800_madgraph",
             ],
         },
     }

--- a/mtt/config/defaults_and_groups.py
+++ b/mtt/config/defaults_and_groups.py
@@ -25,7 +25,7 @@ def set_defaults(
         "reducer": "default",
         "producer": None,
         "weight_producer": "all_weights",
-        "hist_producer": "cf_default",
+        "hist_producer": "all_weights",
         "ml_model": None,
         "inference_model": "an_v12_simplified__m7000_w70",
         "categories": [

--- a/mtt/config/run3/new_mtt_config.py
+++ b/mtt/config/run3/new_mtt_config.py
@@ -241,7 +241,7 @@ def add_new_config(
     verify_config_processes(cfg, warn=True)
 
     # add tagger working points
-    cfg.x.btag_wp_names = btag_params(cfg)
+    cfg.x.btag_wp = btag_params(cfg)
     cfg.x.toptag_wp = toptag_params(cfg)
 
     #
@@ -314,7 +314,7 @@ def add_new_config(
             "btagger": {
                 "column": "btagDeepFlavB" if year != 2024 else "btagUParTAK4B",
                 # "column": "btagDeepFlavB" if year != 2024 else "btagPNetB",
-                "wp": cfg.x.btag_wp_names.deepjet.medium if year != 2024 else cfg.x.btag_wp_names.UParTAK4.medium,
+                "wp": cfg.x.btag_wp.deepjet.medium if year != 2024 else cfg.x.btag_wp.btagUParTAK4B.medium,
                 # "wp": cfg.x.btag_wp.deepjet.medium if year != 2024 else cfg.x.btag_wp.particle_net.medium,
             },
         },
@@ -427,9 +427,12 @@ def add_new_config(
             "lumi_13p6TeV_2023": 0.013j,
         })
     elif year == 2024:
-        cfg.x.luminosity = Number(109_080.0, {  # TODO: update number
+        cfg.x.luminosity = Number(109_080.0, {
             "lumi_13p6TeV_2024": 0.013j,
         })
+        # cfg.x.luminosity = Number(109_095.0, {  # FIXME: SWITCH WHEN RERUNNING
+        #     "lumi_13p6TeV_2024": 0.013j,  # check error
+        # })
         # processed lumi for limited configs
         # cfg.x.luminosity = Number(995.223558512, {
         #     "lumi_13p6TeV_2024": 0.013j,
@@ -532,6 +535,18 @@ def add_new_config(
     # read in JEC sources from file
     with open(os.path.join(thisdir, "jec_sources.yaml"), "r") as f:
         all_jec_sources = yaml.load(f, yaml.Loader)["names"]
+    btag_uncs_bc = [
+        "fsrdef", "isrdef",
+        "hdamp", "jer", "jes",
+        "mass", "statistic",
+        "tune",
+    ]
+    btag_uncs_bc_full = [f"{unc}_bc" for unc in btag_uncs_bc] + ["bc"]
+    btag_uncs_light = [
+        "",
+        "correlated", "uncorrelated",
+    ]
+    btag_uncs_light_full = [f"{unc}_light" for unc in btag_uncs_light] + ["light"]
 
     # declare the shifts
     def add_shifts(cfg):
@@ -632,15 +647,6 @@ def add_new_config(
                 )
         else:
             # https://cms-analysis-corrections.docs.cern.ch/corrections_era/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/BTV/2025-08-19/#btagging_preliminaryjsongz  # noqa
-            btag_uncs_bc = [
-                "fsrdef", "isrdef",
-                "hdamp", "jer", "jes",
-                "mass", "statistic",
-                "tune",
-            ]
-            btag_uncs_light = [
-                "correlated", "uncorrelated",
-            ]
             for i, unc in enumerate(btag_uncs_bc):
                 cfg.add_shift(name=f"btag_{unc}_bc_up", id=501 + 4 * i, type="shape")
                 cfg.add_shift(name=f"btag_{unc}_bc_down", id=502 + 4 * i, type="shape")
@@ -648,7 +654,7 @@ def add_new_config(
                     cfg,
                     f"btag_{unc}_bc",
                     {
-                        f"btag_weight_{unc}_bc": f"btag_weight_{unc}_bc_" + "{direction}",
+                        f"btag_weight": f"btag_weight_{unc}_bc_" + "{direction}",
                     },
                 )
             for i, unc in enumerate(btag_uncs_light):
@@ -658,7 +664,7 @@ def add_new_config(
                     cfg,
                     f"btag_{unc}_light",
                     {
-                        f"btag_weight_{unc}_light": f"btag_weight_{unc}_light_" + "{direction}",
+                        f"btag_weight": f"btag_weight_{unc}_light_" + "{direction}",
                     },
                 )
 
@@ -670,14 +676,14 @@ def add_new_config(
                 cfg,
                 "btag_bc",
                 {
-                    "btag_weight_bc": "btag_weight_bc_" + "{direction}",
+                    "btag_weight": "btag_weight_bc_" + "{direction}",
                 },
             )
             add_shift_aliases(
                 cfg,
                 "btag_light",
                 {
-                    "btag_weight_light": "btag_weight_light_" + "{direction}",
+                    "btag_weight": "btag_weight_light_" + "{direction}",
                 },
             )
         # jet energy scale (JEC) uncertainty variations
@@ -754,6 +760,7 @@ def add_new_config(
 
     # event weight columns as keys in an OrderedDict, mapped to shift instances they depend on
     get_shifts = functools.partial(get_shifts_from_sources, cfg)
+    full_btag_uncs = btag_uncs_bc_full + btag_uncs_light_full
     cfg.x.event_weights = DotDict({
         "normalization_weight": [],
         "pu_weight": get_shifts("minbias_xs"),
@@ -761,7 +768,7 @@ def add_new_config(
         "muon_iso_weight": get_shifts("muon_iso"),
         "electron_reco_weight": get_shifts("electron_reco"),
         "electron_id_iso_weight": get_shifts("electron_id_iso"),
-        "btag_weight": get_shifts("btag_bc", "btag_light"),
+        "btag_weight": get_shifts(*(f"btag_{unc}" for unc in full_btag_uncs)),
         # "ISR": get_shifts("ISR"),
         # "FSR": get_shifts("FSR"),
         # TODO: add scale and PDF weights, where available

--- a/mtt/config/run3/new_mtt_config.py
+++ b/mtt/config/run3/new_mtt_config.py
@@ -633,18 +633,42 @@ def add_new_config(
                 "tune",
             ]
             for i, unc in enumerate(btag_uncs):
-                cfg.add_shift(name=f"btag_{unc}_up", id=501 + 2 * i, type="shape")
-                cfg.add_shift(name=f"btag_{unc}_down", id=502 + 2 * i, type="shape")
+                cfg.add_shift(name=f"btag_{unc}_bc_up", id=501 + 4 * i, type="shape")
+                cfg.add_shift(name=f"btag_{unc}_bc_down", id=502 + 4 * i, type="shape")
+                cfg.add_shift(name=f"btag_{unc}_light_up", id=503 + 4 * i, type="shape")
+                cfg.add_shift(name=f"btag_{unc}_light_down", id=504 + 4 * i, type="shape")
                 add_shift_aliases(
                     cfg,
-                    f"btag_{unc}",
+                    f"btag_{unc}_bc",
                     {
-                        # UPDATED FOR 2024 USING UParTAK4B for b-tagging
-                        "normalized_btag_weight_upart": f"btagUParTAK4B_shape_weight_{unc}_" + "{direction}",
-                        "normalized_njet_btag_weight_upart": f"btagUParTAK4B_shape_weight_{unc}_" + "{direction}",
+                        f"btag_weight_{unc}_bc": f"btag_weight_{unc}_bc_" + "{direction}",
                     },
                 )
-
+                add_shift_aliases(
+                    cfg,
+                    f"btag_{unc}_light",
+                    {
+                        f"btag_weight_{unc}_light": f"btag_weight_{unc}_light_" + "{direction}",
+                    },
+                )
+            cfg.add_shift(name="btag_bc_up", id=501 + 4 * len(btag_uncs), type="shape")
+            cfg.add_shift(name="btag_bc_down", id=502 + 4 * len(btag_uncs), type="shape")
+            cfg.add_shift(name="btag_light_up", id=503 + 4 * len(btag_uncs), type="shape")
+            cfg.add_shift(name="btag_light_down", id=504 + 4 * len(btag_uncs), type="shape")
+            add_shift_aliases(
+                cfg,
+                "btag_bc",
+                {
+                    "btag_weight_bc": "btag_weight_bc_" + "{direction}",
+                },
+            )
+            add_shift_aliases(
+                cfg,
+                "btag_light",
+                {
+                    "btag_weight_light": "btag_weight_light_" + "{direction}",
+                },
+            )
         # jet energy scale (JEC) uncertainty variations
         for jec_source in cfg.x.jec.Jet.uncertainty_sources:
             idx = all_jec_sources.index(jec_source)
@@ -743,13 +767,13 @@ def add_new_config(
             # TODO figure out which datasets should be grouped together;
             # for now, don't group any datasets together and treat each type of dataset separately
             cfg.x.btag_wp_eff_groups = [
-                ["tt_*"],
-                ["st_*"],
-                ["dy_*"],
-                ["w_lnu_*"],
-                ["ww_*", "wz_*", "zz_*"],
-                ["qcd_*"],
-                ["zprime_tt_*"],
+                ["tt_*", "st_*", "zprime_tt_*", "qcd_*", "ww_*", "dy_*", "w_lnu_*", "wz_*", "zz_*"],
+                # ["dy_*"],
+                # ["w_lnu_*"],
+                # ["ww_*", "wz_*", "zz_*"],
+                # ["qcd_*"],
+                # ["zprime_tt_*"],
+                # ["dy_*", "w_lnu_*", "wz_*", "zz_*"],
             ]
             group_matched = False
             for i, dataset_pattern in enumerate(cfg.x.btag_wp_eff_groups):

--- a/mtt/config/run3/new_mtt_config.py
+++ b/mtt/config/run3/new_mtt_config.py
@@ -198,9 +198,11 @@ def add_new_config(
         "dy": "#FBFF36",  # yellow
         "vv": "#B900FC",  # pink
         "other": "#999999",  # grey
-        "zprime_m500_w5": "#000000",  # black
-        "zprime_m1000_w???": "#CCCCCC",  # light gray
-        "zprime_m3000_w???": "#666666",  # dark gray
+    }
+    zprime_colors = {
+        "zprime_tt_m500_w5": "#006400",  # black
+        "zprime_tt_m4000_w40": "#98FB98",  # light gray
+        "zprime_tt_m7000_w70": "#aaaaaa",  # very dark gray
     }
 
     # process settings groups to quickly define settings for ProcessPlots
@@ -214,21 +216,25 @@ def add_new_config(
             ],
         }
 
-        # zprime_base_label = r"Z'$\rightarrow$ $t\overline{t}$"
-        # zprime_mass_labels = {
-        #     # "zprime_tt_m500_w50": "$m$ = 0.5 TeV",
-        #     # "zprime_tt_m1000_w100": "$m$ = 1 TeV",
-        #     # "zprime_tt_m3000_w300": "$m$ = 3 TeV",
-        #     "zprime_tt_m7000_w70": "$m$ = 7 TeV",
-        # }
+        zprime_base_label = r"Z'"
+        zprime_mass_labels = {
+            "zprime_tt_m500_w5": "$m$ = 0.5 TeV, $\Gamma$/$m$ = 1%",
+            "zprime_tt_m4000_w40": "$m$ = 4 TeV, $\Gamma$/$m$ = 1%",
+            "zprime_tt_m7000_w70": "$m$ = 7 TeV, $\Gamma$/$m$ = 1%",
+        }
 
-        # for proc, zprime_mass_label in zprime_mass_labels.items():
-        #     proc_inst = cfg.get_process(proc)
-        #     proc_inst.label = f"{zprime_base_label} ({zprime_mass_label})"
+        for proc, zprime_mass_label in zprime_mass_labels.items():
+            proc_inst = cfg.get_process(proc)
+            proc_inst.label = f"{zprime_base_label} ({zprime_mass_label})"
+            if proc in zprime_colors:
+                proc_inst.color1 = zprime_colors[proc]
+                proc_inst.color2 = zprime_colors[proc]
 
         for proc in cfg.processes:
-            cfg.get_process(proc).color1 = colors.get(proc.name, "#aaaaaa")
-            cfg.get_process(proc).color2 = colors.get(proc.name, "#000000")
+            proc_inst = cfg.get_process(proc)
+            if proc.name not in zprime_colors.keys():
+                proc_inst.color1 = colors.get(proc.name, "#aaaaaa")
+                proc_inst.color2 = colors.get(proc.name, "#000000")
 
     # verify that the root processes of each dataset (or one of their
     # ancestor processes) are registered in the config

--- a/mtt/config/run3/new_mtt_config.py
+++ b/mtt/config/run3/new_mtt_config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 import os
+import law
 
 import yaml
 from scinum import Number
@@ -684,7 +685,9 @@ def add_new_config(
     # add the shifts
     add_shifts(cfg)
 
-    cfg.x.btag_sf = btag_sf_cfg(year)
+    # cfg.x.btag_sf = btag_sf_cfg(year)
+    cfg.x.btag_wp_count_config = btag_sf_cfg(cfg, 2024)["btag_wp_count_config"]
+    cfg.x.btag_wp_sf_config = btag_sf_cfg(cfg, 2024)["btag_wp_sf_config"]
     cfg.x.toptag_sf = toptag_sf_cfg()
 
     cfg.x.electron_sf = lepton_sf_cfg(cfg, "electron")
@@ -722,9 +725,37 @@ def add_new_config(
         # "pdf_weight": ???,
     })
 
-    # event weights only present in certain datasets
     for dataset in cfg.datasets:
+        # event weights only present in certain datasets
         dataset.x.event_weights = DotDict()
+
+        # group datasets together for btag WP efficiency calculation in 2024
+        if year == 2024:
+            # TODO figure out which datasets should be grouped together;
+            # for now, don't group any datasets together and treat each type of dataset separately
+            cfg.x.btag_wp_eff_groups = [
+                ["tt_*"],
+                ["st_*"],
+                ["dy_*"],
+                ["w_lnu_*"],
+                ["ww_*", "wz_*", "zz_*"],
+                ["qcd_*"],
+                ["zprime_tt_*"],
+            ]
+            group_matched = False
+            for i, dataset_pattern in enumerate(cfg.x.btag_wp_eff_groups):
+                if law.util.multi_match(dataset.name, dataset_pattern):
+                    if group_matched:
+                        raise ValueError(
+                            f"dataset '{dataset.name}' already has a btag WP group assigned! Cannot assign it to more "
+                            "than one group",
+                        )
+                    group_matched = True
+                    dataset.add_tag(f"btag_wp_eff_group_{i}")
+            if not group_matched and dataset.is_mc:
+                raise ValueError(f"no btag_wp_eff_group_* assigned to dataset '{dataset.name}'")
+            if group_matched and dataset.is_data:
+                raise ValueError(f"must not assign btag_wp_eff_group_* to dataset '{dataset.name}'")
 
         # TTbar: top pt reweighting
         if dataset.has_tag("is_ttbar"):
@@ -785,7 +816,7 @@ def add_new_config(
             vnano=15,
             era="24CDEReprocessingFGHIPrompt-Summer24",
             pog_directories={"dc": "Collisions24"},
-            snapshot=CATSnapshot(btv="2025-12-03", dc="2025-07-25", egm="2025-12-03", jme="2025-12-02", muo="2025-11-27", lum="2025-12-02"),  # noqa: E501
+            snapshot=CATSnapshot(btv="2026-01-30", dc="2025-07-25", egm="2025-12-15", jme="2025-12-02", muo="2025-11-27", lum="2025-12-02"),  # noqa: E501
         ),
     }[(year, campaign.x.postfix, vnano)]
     cfg.x.cat_info = cat_info
@@ -832,8 +863,10 @@ def add_new_config(
     if year != 2024:
         add_external("btag_sf_corr", (cat_info.get_file("btv", "btagging.json.gz"), "v1"))
     else:
-        # SF stored in preliminary file for 2024 for now?
-        add_external("btag_sf_corr", (cat_info.get_file("btv", "btagging_preliminary.json.gz"), "v1"))  # noqa: E501
+        # SF stored in preliminary file for 2024 for now
+        # add_external("btag_sf_corr", (cat_info.get_file("btv", "btagging_preliminary.json.gz"), "v1"))  # noqa: E501
+        # use custom file with merged SF for both b/c and light jets
+        add_external("btag_wp_sf_corr", ("/data/dust/user/matthiej/mttbar/mtt/config/run3/btagging_preliminary_merged.json.gz", "v1"))  # noqa: E501
 
     # updated jet id
     add_external("jet_id", (cat_info.get_file("jme", "jetid.json.gz"), "v1"))

--- a/mtt/config/run3/new_mtt_config.py
+++ b/mtt/config/run3/new_mtt_config.py
@@ -626,17 +626,18 @@ def add_new_config(
                 )
         else:
             # https://cms-analysis-corrections.docs.cern.ch/corrections_era/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/BTV/2025-08-19/#btagging_preliminaryjsongz  # noqa
-            btag_uncs = [
+            btag_uncs_bc = [
                 "fsrdef", "isrdef",
                 "hdamp", "jer", "jes",
                 "mass", "statistic",
                 "tune",
             ]
-            for i, unc in enumerate(btag_uncs):
+            btag_uncs_light = [
+                "correlated", "uncorrelated",
+            ]
+            for i, unc in enumerate(btag_uncs_bc):
                 cfg.add_shift(name=f"btag_{unc}_bc_up", id=501 + 4 * i, type="shape")
                 cfg.add_shift(name=f"btag_{unc}_bc_down", id=502 + 4 * i, type="shape")
-                cfg.add_shift(name=f"btag_{unc}_light_up", id=503 + 4 * i, type="shape")
-                cfg.add_shift(name=f"btag_{unc}_light_down", id=504 + 4 * i, type="shape")
                 add_shift_aliases(
                     cfg,
                     f"btag_{unc}_bc",
@@ -644,6 +645,9 @@ def add_new_config(
                         f"btag_weight_{unc}_bc": f"btag_weight_{unc}_bc_" + "{direction}",
                     },
                 )
+            for i, unc in enumerate(btag_uncs_light):
+                cfg.add_shift(name=f"btag_{unc}_light_up", id=503 + 4 * i, type="shape")
+                cfg.add_shift(name=f"btag_{unc}_light_down", id=504 + 4 * i, type="shape")
                 add_shift_aliases(
                     cfg,
                     f"btag_{unc}_light",
@@ -651,10 +655,11 @@ def add_new_config(
                         f"btag_weight_{unc}_light": f"btag_weight_{unc}_light_" + "{direction}",
                     },
                 )
-            cfg.add_shift(name="btag_bc_up", id=501 + 4 * len(btag_uncs), type="shape")
-            cfg.add_shift(name="btag_bc_down", id=502 + 4 * len(btag_uncs), type="shape")
-            cfg.add_shift(name="btag_light_up", id=503 + 4 * len(btag_uncs), type="shape")
-            cfg.add_shift(name="btag_light_down", id=504 + 4 * len(btag_uncs), type="shape")
+
+            cfg.add_shift(name="btag_bc_up", id=501 + 4 * len(btag_uncs_bc), type="shape")
+            cfg.add_shift(name="btag_bc_down", id=502 + 4 * len(btag_uncs_bc), type="shape")
+            cfg.add_shift(name="btag_light_up", id=503 + 4 * len(btag_uncs_light), type="shape")
+            cfg.add_shift(name="btag_light_down", id=504 + 4 * len(btag_uncs_light), type="shape")
             add_shift_aliases(
                 cfg,
                 "btag_bc",

--- a/mtt/config/run3/new_mtt_config.py
+++ b/mtt/config/run3/new_mtt_config.py
@@ -579,15 +579,21 @@ def add_new_config(
 
         # event weights due to muon scale factors
         if not cfg.has_tag("skip_muon_weights"):
-            cfg.add_shift(name="muon_up", id=111, type="shape")
-            cfg.add_shift(name="muon_down", id=112, type="shape")
-            add_shift_aliases(cfg, "muon", {"muon_weight": "muon_weight_{direction}"})
+            cfg.add_shift(name="muon_id_up", id=111, type="shape")
+            cfg.add_shift(name="muon_id_down", id=112, type="shape")
+            add_shift_aliases(cfg, "muon_id", {"muon_id_weight": "muon_id_weight_{direction}"})
+            cfg.add_shift(name="muon_iso_up", id=113, type="shape")
+            cfg.add_shift(name="muon_iso_down", id=114, type="shape")
+            add_shift_aliases(cfg, "muon_iso", {"muon_iso_weight": "muon_iso_weight_{direction}"})
 
         # event weights due to electron scale factors
         if not cfg.has_tag("skip_electron_weights"):
-            cfg.add_shift(name="electron_up", id=121, type="shape")
-            cfg.add_shift(name="electron_down", id=122, type="shape")
-            add_shift_aliases(cfg, "electron", {"electron_weight": "electron_weight_{direction}"})
+            cfg.add_shift(name="electron_reco_up", id=121, type="shape")
+            cfg.add_shift(name="electron_reco_down", id=122, type="shape")
+            add_shift_aliases(cfg, "electron_reco", {"electron_reco_weight": "electron_reco_weight_{direction}"})
+            cfg.add_shift(name="electron_id_iso_up", id=123, type="shape")
+            cfg.add_shift(name="electron_id_iso_down", id=124, type="shape")
+            add_shift_aliases(cfg, "electron_id_iso", {"electron_id_iso_weight": "electron_id_iso_weight_{direction}"})
 
         # V+jets reweighting
         cfg.add_shift(name="vjets_up", id=201, type="shape")
@@ -690,11 +696,11 @@ def add_new_config(
     cfg.x.btag_wp_sf_config = btag_sf_cfg(cfg, 2024)["btag_wp_sf_config"]
     cfg.x.toptag_sf = toptag_sf_cfg()
 
-    cfg.x.electron_sf = lepton_sf_cfg(cfg, "electron")
+    cfg.x.electron_reco_sf_config = lepton_sf_cfg(cfg, "electron")["electron_reco_sf_config"]
+    cfg.x.electron_id_iso_sf_config = lepton_sf_cfg(cfg, "electron")["electron_id_iso_sf_config"]
 
-    cfg.x.muon_sf_names = lepton_sf_cfg(cfg, "muon")[0]
-    cfg.x.muon_id_sf_names = lepton_sf_cfg(cfg, "muon")[1]
-    cfg.x.muon_iso_sf_names = lepton_sf_cfg(cfg, "muon")[2]
+    cfg.x.muon_iso_sf_config = lepton_sf_cfg(cfg, "muon")["muon_iso_config"]
+    cfg.x.muon_id_sf_config = lepton_sf_cfg(cfg, "muon")["muon_id_config"]
 
     cfg.x.met_phi_correction = met_phi_cfg(cfg)  # METPhiConfig object
     cfg.x.jet_id = jet_id_cfg()["Jet"]  # JetIdConfig object
@@ -716,8 +722,11 @@ def add_new_config(
     cfg.x.event_weights = DotDict({
         "normalization_weight": [],
         "pu_weight": get_shifts("minbias_xs"),
-        "muon_weight": get_shifts("muon"),
-        "electron_weight": get_shifts("electron"),
+        "muon_id_weight": get_shifts("muon_id"),
+        "muon_iso_weight": get_shifts("muon_iso"),
+        "electron_reco_weight": get_shifts("electron_reco"),
+        "electron_id_iso_weight": get_shifts("electron_id_iso"),
+        "btag_weight": get_shifts("btag_bc", "btag_light"),
         # "ISR": get_shifts("ISR"),
         # "FSR": get_shifts("FSR"),
         # TODO: add scale and PDF weights, where available

--- a/mtt/config/taggers.py
+++ b/mtt/config/taggers.py
@@ -89,7 +89,7 @@ def btag_params(
                 # },
             },
             "2024": {
-                "UParTAK4": {
+                "btagUParTAK4B": {
                     "loose": 0.0246,
                     "medium": 0.1272,
                     "tight": 0.4648,

--- a/mtt/config/taggers.py
+++ b/mtt/config/taggers.py
@@ -93,6 +93,8 @@ def btag_params(
                     "loose": 0.0246,
                     "medium": 0.1272,
                     "tight": 0.4648,
+                    "xtight": 0.6298,
+                    "xxtight": 0.9739,
                 },
                 "particle_net": {
                     # FIXME: placeholder values, need to be updated when official values are available

--- a/mtt/config/variables.py
+++ b/mtt/config/variables.py
@@ -345,9 +345,10 @@ def add_variables(config: od.Config) -> None:
         y_title="Events",
     )
     config.add_variable(
-        name="gen_ttbar_mass_narrow",
+        name="gen_ttbar_mass_narrow_ext",
         expression="TTbar.gen_mass",
-        binning=config.get_variable("ttbar_mass_narrow").binning,
+        # binning=config.get_variable("ttbar_mass_narrow").binning,
+        binning=(100, 0, 9000),
         unit="GeV",
         x_title=r"$m({t}\overline{t})^{gen}$",
         y_title="Events",

--- a/mtt/config/variables.py
+++ b/mtt/config/variables.py
@@ -60,7 +60,7 @@ def add_variables(config: od.Config) -> None:
 
     # Jets (4 pt-leading jets)
     for i in range(4):
-        for obj in ("Jet", "FatJet"):
+        for obj in ("Jet", "FatJet", "BJet", "LightJet"):
             config.add_variable(
                 name=f"{obj.lower()}{i+1}_pt",
                 expression=f"{obj}.pt[:,{i}]",
@@ -785,6 +785,12 @@ def add_variables_ml(config: od.Config) -> None:
             name=f"AN_v12_mli_jet_btagUParTAK4B_{i}",
             expression=f"{ns}.jet_btagUParTAK4B_{i}",
             binning=v12_btag_binning,
+            x_title=f"ML input (AK4 jet #{i} UParTAK4B b tag score) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_jet_btagUParTAK4B_{i}_rebinned",
+            expression=f"{ns}.jet_btagUParTAK4B_{i}",
+            binning=[0.0, 0.0246, 0.1272, 0.4648, 0.6298, 0.9739, 1.0],
             x_title=f"ML input (AK4 jet #{i} UParTAK4B b tag score) - ANv12",
         )
 

--- a/mtt/config/variables.py
+++ b/mtt/config/variables.py
@@ -83,6 +83,14 @@ def add_variables(config: od.Config) -> None:
                 binning=(40, -3.2, 3.2),
                 x_title=rf"{obj} {i+1} $\phi$",
             )
+            # config.add_variable(
+            #     name=f"{obj.lower()}{i+1}_btagUParTAK4B_buckets",
+            #     expression=f"{obj}.btagUParTAK4B_buckets[:,{i}]",
+            #     null_value=EMPTY_FLOAT,
+            #     binning=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            #     unit="GeV",
+            #     x_title=rf"{obj} {i+1} number of b tagging wp passed",
+            # )
 
     config.add_variable(
         name="fatjet_tau32",
@@ -519,6 +527,7 @@ def add_variables_ml(config: od.Config) -> None:
     v12_tau_binning = (24, 0.0, 1.2)
     v12_njets_binning = (20, 0.0, 20.0)
     v12_nfatjets_binning = (20, 0.0, 20.0)
+    v12_nbjets_binning = (20, 0.0, 20.0)
 
     variables = {
         "pt": [(100, 0, 3000), "$p_{T}$", "GeV"],
@@ -701,6 +710,13 @@ def add_variables_ml(config: od.Config) -> None:
         x_title=r"ML input (# of AK8 jets) - ANv12",
     )
 
+    config.add_variable(
+        name="AN_v12_mli_n_bjet",
+        expression=f"{ns}.n_bjet",
+        binning=v12_nbjets_binning,
+        x_title=r"ML input (# of b tagged AK4 jets) - ANv12",
+    )
+
     # binning adjusted variables to better compare with AN
 
     config.add_variable(
@@ -748,116 +764,208 @@ def add_variables_ml(config: od.Config) -> None:
         x_title=r"ML input (MET $\phi$) - ANv12",
     )
 
+    config.add_variable(
+        name="AN_v12_mli_ht_jets",
+        expression=f"{ns}.ht_jets",
+        binning=(100, 0.0, 5000.0),
+        unit="GeV",
+        x_title=r"ML input (HT of AK4 jets) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_ht_fatjets",
+        expression=f"{ns}.ht_fatjets",
+        binning=(100, 0.0, 5000.0),
+        unit="GeV",
+        x_title=r"ML input (HT of AK8 jets) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_ht_bjets",
+        expression=f"{ns}.ht_bjets",
+        binning=(100, 0.0, 5000.0),
+        unit="GeV",
+        x_title=r"ML input (HT of b tagged AK4 jets) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_ht_sum",
+        expression=f"{ns}.ht_sum",
+        binning=(100, 0.0, 5000.0),
+        unit="GeV",
+        x_title=r"ML input (HT of all jets) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_st",
+        expression=f"{ns}.st",
+        binning=(100, 0.0, 5000.0),
+        unit="GeV",
+        x_title=r"ML input ($S_{T}$) - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_leading_jets_deltar",
+        expression=f"{ns}.leading_jets_deltar",
+        binning=(40, 0, 5),
+        x_title=rf"ML input $\Delta R$ between leading and subleading AK4 jets - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_leading_fatjets_deltar",
+        expression=f"{ns}.leading_fatjets_deltar",
+        binning=(40, 0, 5),
+        x_title=rf"ML input $\Delta R$ between leading and subleading AK8 jets - ANv12",
+    )
+
+    config.add_variable(
+        name="AN_v12_mli_leading_jetfatjet_deltar",
+        expression=f"{ns}.leading_jetfatjet_deltar",
+        binning=(40, 0, 5),
+        x_title=rf"ML input $\Delta R$ between leading AK4 jet and leading AK8 jet - ANv12",
+    )
+
     for i in range(1, 6):
         config.add_variable(
-            name=f"AN_v12_mli_jet_energy_{i}",
-            expression=f"{ns}.jet_energy_{i}",
+            name=f"AN_v12_mli_jet_{i}_energy",
+            expression=f"{ns}.jet_{i}_energy",
             binning=v12_energy_binning_jets,
             unit="GeV",
             x_title=f"ML input (AK4 jet #{i} $E$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_jet_pt_{i}",
-            expression=f"{ns}.jet_pt_{i}",
+            name=f"AN_v12_mli_jet_{i}_pt",
+            expression=f"{ns}.jet_{i}_pt",
             binning=v12_pt_binning_jets,
             unit="GeV",
             x_title=f"ML input (AK4 jet #{i} $p_T$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_jet_eta_{i}",
-            expression=f"{ns}.jet_eta_{i}",
+            name=f"AN_v12_mli_jet_{i}_eta",
+            expression=f"{ns}.jet_{i}_eta",
             binning=v12_eta_binning,
             x_title=rf"ML input (AK4 jet #{i} $\eta$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_jet_phi_{i}",
-            expression=f"{ns}.jet_phi_{i}",
+            name=f"AN_v12_mli_jet_{i}_phi",
+            expression=f"{ns}.jet_{i}_phi",
             binning=v12_phi_binning,
             x_title=rf"ML input (AK4 jet #{i} $\phi$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_jet_mass_{i}",
-            expression=f"{ns}.jet_mass_{i}",
+            name=f"AN_v12_mli_jet_{i}_mass",
+            expression=f"{ns}.jet_{i}_mass",
             binning=v12_mass_binning_jets,
             unit="GeV",
             x_title=f"ML input (AK4 jet #{i} $m$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_jet_btagUParTAK4B_{i}",
-            expression=f"{ns}.jet_btagUParTAK4B_{i}",
+            name=f"AN_v12_mli_jet_{i}_btagUParTAK4B",
+            expression=f"{ns}.jet_{i}_btagUParTAK4B",
             binning=v12_btag_binning,
             x_title=f"ML input (AK4 jet #{i} UParTAK4B b tag score) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_jet_btagUParTAK4B_{i}_rebinned",
-            expression=f"{ns}.jet_btagUParTAK4B_{i}",
-            binning=[0.0, 0.0246, 0.1272, 0.4648, 0.6298, 0.9739, 1.0],
-            x_title=f"ML input (AK4 jet #{i} UParTAK4B b tag score) - ANv12",
+            name=f"AN_v12_mli_jet_{i}_btagUParTAK4B_buckets",
+            expression=f"{ns}.jet_{i}_btagUParTAK4B_buckets",
+            binning=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            x_title=f"ML input (AK4 jet #{i} UParTAK4B b tag score buckets) - ANv12",
+        )
+        for wp in config.x.btag_wp["btagUParTAK4B"].keys():
+            config.add_variable(
+                name=f"AN_v12_mli_jet_{i}_btagUParTAK4B_pass_{wp}",
+                expression=f"{ns}.jet_{i}_btagUParTAK4B_pass_{wp}",
+                binning=(2, -0.5, 1.5),
+                x_title=f"ML input (AK4 jet #{i} UParTAK4B b tag score pass {wp}) - ANv12",
+            )
+        config.add_variable(
+            name=f"AN_v12_mli_jet_{i}_lepton_deltar",
+            expression=f"{ns}.jet_{i}_lepton_deltar",
+            binning=(40, 0, 5),
+            x_title=rf"$\Delta R(AK4 jet #{i}, lepton)$",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_jet_{i}_met_deltar",
+            expression=f"{ns}.jet_{i}_met_deltar",
+            binning=(40, 0, 5),
+            x_title=rf"$\Delta R(AK4 jet #{i}, MET)$",
         )
 
     for i in range(1, 4):
         config.add_variable(
-            name=f"AN_v12_mli_fatjet_energy_{i}",
-            expression=f"{ns}.fatjet_energy_{i}",
+            name=f"AN_v12_mli_fatjet_{i}_energy",
+            expression=f"{ns}.fatjet_{i}_energy",
             binning=v12_energy_binning_jets,
             unit="GeV",
             x_title=f"ML input (AK8 jet #{i} $E$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_fatjet_pt_{i}",
-            expression=f"{ns}.fatjet_pt_{i}",
+            name=f"AN_v12_mli_fatjet_{i}_pt",
+            expression=f"{ns}.fatjet_{i}_pt",
             binning=v12_pt_binning_jets,
             unit="GeV",
             x_title=f"ML input (AK8 jet #{i} $p_T$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_fatjet_eta_{i}",
-            expression=f"{ns}.fatjet_eta_{i}",
+            name=f"AN_v12_mli_fatjet_{i}_eta",
+            expression=f"{ns}.fatjet_{i}_eta",
             binning=v12_eta_binning,
             x_title=rf"ML input (AK8 jet #{i} $\eta$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_fatjet_phi_{i}",
-            expression=f"{ns}.fatjet_phi_{i}",
+            name=f"AN_v12_mli_fatjet_{i}_phi",
+            expression=f"{ns}.fatjet_{i}_phi",
             binning=v12_phi_binning,
             x_title=rf"ML input (AK8 jet #{i} $\phi$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_fatjet_msoftdrop_{i}",
-            expression=f"{ns}.fatjet_msoftdrop_{i}",
+            name=f"AN_v12_mli_fatjet_{i}_msoftdrop",
+            expression=f"{ns}.fatjet_{i}_msoftdrop",
             binning=v12_msoftdrop_binning,
             unit="GeV",
             x_title=f"ML input (AK8 jet #{i} $m_{{SD}}$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_fatjet_tau21_{i}",
-            expression=f"{ns}.fatjet_tau21_{i}",
+            name=f"AN_v12_mli_fatjet_{i}_tau21",
+            expression=f"{ns}.fatjet_{i}_tau21",
             binning=v12_tau_binning,
             x_title=rf"ML input (AK8 jet #{i} $\tau_{{21}}$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_fatjet_tau32_{i}",
-            expression=f"{ns}.fatjet_tau32_{i}",
+            name=f"AN_v12_mli_fatjet_{i}_tau32",
+            expression=f"{ns}.fatjet_{i}_tau32",
             binning=v12_tau_binning,
             x_title=rf"ML input (AK8 jet #{i} $\tau_{{32}}$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_fatjet_tau1_{i}",
-            expression=f"{ns}.fatjet_tau1_{i}",
+            name=f"AN_v12_mli_fatjet_{i}_tau1",
+            expression=f"{ns}.fatjet_{i}_tau1",
             binning=tau_binning,
             x_title=rf"ML input (AK8 jet #{i} $\tau_{{1}}$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_fatjet_tau2_{i}",
-            expression=f"{ns}.fatjet_tau2_{i}",
+            name=f"AN_v12_mli_fatjet_{i}_tau2",
+            expression=f"{ns}.fatjet_{i}_tau2",
             binning=tau_binning,
             x_title=rf"ML input (AK8 jet #{i} $\tau_{{2}}$) - ANv12",
         )
         config.add_variable(
-            name=f"AN_v12_mli_fatjet_tau3_{i}",
-            expression=f"{ns}.fatjet_tau3_{i}",
+            name=f"AN_v12_mli_fatjet_{i}_tau3",
+            expression=f"{ns}.fatjet_{i}_tau3",
             binning=tau_binning,
             x_title=rf"ML input (AK8 jet #{i} $\tau_{{3}}$) - ANv12",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_{i}_lepton_deltar",
+            expression=f"{ns}.fatjet_{i}_lepton_deltar",
+            binning=(40, 0, 5),
+            x_title=rf"$\Delta R(AK8 jet #{i}, lepton)$",
+        )
+        config.add_variable(
+            name=f"AN_v12_mli_fatjet_{i}_met_deltar",
+            expression=f"{ns}.fatjet_{i}_met_deltar",
+            binning=(40, 0, 5),
+            x_title=rf"$\Delta R(AK8 jet #{i}, MET)$",
         )
 
     # -- helper functions
@@ -870,8 +978,8 @@ def add_variables_ml(config: od.Config) -> None:
 
             # add variable to config
             config.add_variable(
-                name=f"mli_{name}_{attr}_{i}",
-                expression=f"{ns}.{name}_{attr}_{i}",
+                name=f"mli_{name}_{i}_{attr}",
+                expression=f"{ns}.{name}_{i}_{attr}",
                 binning=binning,
                 unit=unit,
                 x_title=f"ML input ({obj_label} #{i+1} {var_label})",

--- a/mtt/ml/categories.py
+++ b/mtt/ml/categories.py
@@ -166,7 +166,7 @@ def add_ml_cats_init(self: Producer) -> None:
 # # FIXME to be tested again, currently disabled
 from mtt.ml.base import MLClassifierBase
 ml_model_names = get_subclasses_deep(MLClassifierBase)
-logger.info(f"deriving {len(ml_model_names)} ML categorizer...")
+logger.info(f"deriving {len(ml_model_names)} ML categorizers...")
 
 for ml_model_name in ml_model_names:
     add_ml_cats.derive(f"add_ml_cats_{ml_model_name}", cls_dict={"ml_model_name": ml_model_name})

--- a/mtt/ml/data_loader.py
+++ b/mtt/ml/data_loader.py
@@ -131,6 +131,7 @@ class MLDatasetLoader:
         else:
             self._events = events[proc_mask]
             self._events = events[events.event_weight >= 0.0]
+            # self._events = events[:10_000]
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.ml_model_inst.cls_name}, {self.process})"
@@ -236,8 +237,8 @@ class MLDatasetLoader:
 
             input_features_sanity_checks(temp_ml_model, mapped_features_for_check)
 
-        except Exception as e:
-            logger.error(f"Input features sanity check failed: {e}")
+        except:
+            logger.error("Input features sanity check failed")
             logger.error(f"Expected (with MLInput prefix): {expected_with_prefix}")
             logger.error(f"Got (with MLInput prefix): {set(mapped_features_for_check)}")
 
@@ -532,7 +533,7 @@ class MLDatasetLoader:
 
         if self.shuffle:
             data = data[self.shuffle_indices]
-        logger.debug(f"Data split into {train_end} training, {val_end - train_end} validation, {self.n_events - val_end} test samples.")  # noqa
+        logger.info(f"Data split into {train_end} training, {val_end - train_end} validation, {self.n_events - val_end} test samples.")  # noqa
 
         return data[:train_end], data[train_end:val_end], data[val_end:]
 

--- a/mtt/ml/derived/mtt_simple.py
+++ b/mtt/ml/derived/mtt_simple.py
@@ -269,6 +269,7 @@ v1_AN_v12 = DenseClassifier.derive("v1_AN_v12", cls_dict={
 })
 
 v2_AN_v12 = v1_AN_v12.derive("v2_AN_v12", cls_dict={
+    # training without t channel single top
     "learningrate": 0.0001,
     "reduce_lr_kwargs": {
         "monitor": "val_loss",
@@ -284,6 +285,44 @@ v2_AN_v12 = v1_AN_v12.derive("v2_AN_v12", cls_dict={
         "start_from_epoch": 20,
         "mode": "min",
     },
+})
+
+# same parameters as v2_AN_v12 but with t channel single top included
+# renaming to keep output files separate from v2_AN_v12
+v3_AN_v12 = v2_AN_v12.derive("v3_AN_v12")
+
+# new training without b tagging scores
+# drop `AN_v12` from name since this is now different from the original ANv12 model
+# also, learningrate and callbacks need to be adapted differently without b tagging scores
+v4_no_btag = v3_AN_v12.derive("v4_no_btag", cls_dict={
+    "input_features": tuple([
+        "n_jet",
+        "n_fatjet",
+    ]) + tuple([
+        f"jet_{var}_{i + 1}"
+        for var in ("energy", "pt", "eta", "phi", "mass")
+        for i in range(5)
+    ]) + tuple([
+        f"fatjet_{var}_{i + 1}"
+        for var in ("energy", "pt", "eta", "phi", "msoftdrop", "tau21", "tau32")
+        for i in range(3)
+    ]) + tuple([
+        f"lepton_{var}"
+        for var in ("energy", "pt", "eta", "phi")
+    ]) + tuple([
+        f"met_{var}"
+        for var in ("pt", "phi")
+    ]),
+    "learningrate": 0.0005,
+    "batchsize": 2 ** 13,
+    "reduce_lr_kwargs": {
+        "monitor": "val_loss",
+        "factor": 0.5,
+        "patience": 5,
+        "min_delta": 0.001,
+        "mode": "min",
+    },
+    "steps_per_epoch": 400.0,
 })
 
 

--- a/mtt/ml/derived/mtt_simple.py
+++ b/mtt/ml/derived/mtt_simple.py
@@ -47,11 +47,11 @@ class DenseClassifier(DenseModelMixin, ModelFitMixin, MLClassifierBase):
         "n_jet",
         "n_fatjet",
     ) + tuple([
-        f"jet_{var}_{i + 1}"
+        f"jet_{i + 1}_{var}"
         for var in ("energy", "pt", "eta", "phi", "mass", "btagUParTAK4B")
         for i in range(5)
     ]) + tuple([
-        f"fatjet_{var}_{i + 1}"
+        f"fatjet_{i + 1}_{var}"
         for var in ("energy", "pt", "eta", "phi", "msoftdrop", "tau21", "tau32")
         for i in range(3)
     ]) + tuple([
@@ -142,7 +142,137 @@ procs_config = DotDict({
 
 # which input features should be used for training
 input_features_config = DotDict({
+    # full feature lists
     "default": DenseClassifier.input_features,
+    "no_btag_scores": tuple([
+        "n_jet",
+        "n_fatjet",
+        "n_bjet",
+    ]) + tuple([
+        f"jet_{i + 1}_{var}"
+        for var in ("energy", "pt", "eta", "phi", "mass")
+        for i in range(5)
+    ]) + tuple([
+        f"fatjet_{i + 1}_{var}"
+        for var in ("energy", "pt", "eta", "phi", "msoftdrop", "tau21", "tau32")
+        for i in range(3)
+    ]) + tuple([
+        f"lepton_{var}"
+        for var in ("energy", "pt", "eta", "phi")
+    ]) + tuple([
+        f"met_{var}"
+        for var in ("pt", "phi")
+    ]),
+    "btag_buckets": tuple([
+        "n_jet",
+        "n_fatjet",
+        "n_bjet",
+    ]) + tuple([
+        f"jet_{i + 1}_{var}"
+        for var in ("energy", "pt", "eta", "phi", "mass", "btagUParTAK4B_buckets")
+        for i in range(5)
+    ]) + tuple([
+        f"fatjet_{i + 1}_{var}"
+        for var in ("energy", "pt", "eta", "phi", "msoftdrop", "tau21", "tau32")
+        for i in range(3)
+    ]) + tuple([
+        f"lepton_{var}"
+        for var in ("energy", "pt", "eta", "phi")
+    ]) + tuple([
+        f"met_{var}"
+        for var in ("pt", "phi")
+    ]),
+    "highlevel": tuple([
+        "n_jet",
+        "n_fatjet",
+        "n_bjet",
+        "ht_jets",
+        "ht_fatjets",
+        "ht_sum",
+        "st",
+        "leading_jets_deltar",
+        "leading_fatjets_deltar",
+        "leading_jetfatjet_deltar",
+    ]) + tuple([
+        f"jet_{i + 1}_{var}"
+        for var in ("pt", "eta", "mass")
+        for i in range(5)
+    ]) + tuple([
+        f"fatjet_{i + 1}_{var}"
+        for var in ("pt", "eta", "msoftdrop", "tau21", "tau32")
+        for i in range(3)
+    ]) + tuple([
+        f"lepton_{var}"
+        for var in ("pt", "eta",)
+    ]) + tuple([
+        f"met_{var}"
+        for var in ("pt", "phi")
+    ]),
+    # atomic feature lists
+    "ak4_jets_all": tuple([
+        f"jet_{i + 1}_{var}"
+        for var in ("energy", "pt", "eta", "phi", "mass")
+        for i in range(5)
+    ]),
+    "ak4_jets_minimal": tuple([
+        f"jet_{i + 1}_{var}"
+        for var in ("pt", "eta", "mass")
+        for i in range(5)
+    ]),
+    "ak8_fatjets_all": tuple([
+        f"fatjet_{i + 1}_{var}"
+        for var in ("energy", "pt", "eta", "phi", "msoftdrop", "tau21", "tau32")
+        for i in range(3)
+    ]),
+    "ak8_fatjets_minimal": tuple([
+        f"fatjet_{i + 1}_{var}"
+        for var in ("pt", "eta", "msoftdrop", "tau21", "tau32")
+        for i in range(3)
+    ]),
+    "lepton_all": tuple([
+        f"lepton_{var}"
+        for var in ("energy", "pt", "eta", "phi")
+    ]),
+    "lepton_minimal": tuple([
+        f"lepton_{var}"
+        for var in ("pt", "eta")
+    ]),
+    "met_all": tuple([
+        f"met_{var}"
+        for var in ("pt", "phi")
+    ]),
+    "btag_scores": tuple([
+        f"jet_{i + 1}_btagUParTAK4B_buckets"
+        for i in range(5)
+    ]),
+    "event_level_all": (
+        "n_jet",
+        "n_fatjet",
+        "n_bjet",
+        "ht_jets",
+        "ht_fatjets",
+        "ht_sum",
+        "st",
+        "leading_jets_deltar",
+        "leading_fatjets_deltar",
+        "leading_jetfatjet_deltar",
+    ),
+    "jet_multiplicity": (
+        "n_jet",
+        "n_fatjet",
+        "n_bjet",
+    ),
+    "ht_variables": (
+        "ht_jets",
+        "ht_fatjets",
+        "ht_sum",
+        "st",
+    ),
+    "deltaR_variables": (
+        "leading_jets_deltar",
+        "leading_fatjets_deltar",
+        "leading_jetfatjet_deltar",
+    ),
 })
 
 # how to setup the train nodes (aka output classes)
@@ -174,6 +304,19 @@ class_factors_config = DotDict({
     "benchmark_from_hbw": {
         "tt": 8,
         "st": 2,
+        "dy": 2,
+        "w_lnu": 1,
+    },
+    "naive_balanced": {
+        # not reasonable, don't use
+        "tt": 250,
+        "st": 20,
+        "dy": 2,
+        "w_lnu": 1,
+    },
+    "more_balanced": {
+        "tt": 10,
+        "st": 4,
         "dy": 2,
         "w_lnu": 1,
     },
@@ -325,8 +468,266 @@ v4_no_btag = v3_AN_v12.derive("v4_no_btag", cls_dict={
     "steps_per_epoch": 400.0,
 })
 
+v5 = v2_AN_v12.derive("v5", cls_dict={
+    "steps_per_epoch": 20.0,
+    "input_features": tuple([
+        "n_jet",
+        "n_fatjet",
+    ]) + tuple([
+        f"jet_{i + 1}_{var}"
+        for var in ("energy", "pt", "eta", "phi", "mass", "btagUParTAK4B_buckets")
+        for i in range(5)
+    ]) + tuple([
+        f"fatjet_{i + 1}_{var}"
+        for var in ("energy", "pt", "eta", "phi", "msoftdrop", "tau21", "tau32")
+        for i in range(3)
+    ]) + tuple([
+        f"lepton_{var}"
+        for var in ("energy", "pt", "eta", "phi")
+    ]) + tuple([
+        f"met_{var}"
+        for var in ("pt", "phi")
+    ]),
+})
 
+v6 = v2_AN_v12.derive("v6", cls_dict={
+    "steps_per_epoch": 20.0,
+    "input_features": input_features_config.no_btag_scores,
+    "learningrate": 0.0001,
+    "reduce_lr_kwargs": {
+        "monitor": "val_loss",
+        "factor": 0.5,
+        "patience": 5,
+        "min_delta": 0.001,
+        "mode": "min",
+    },
+    "early_stopping_kwargs": {
+        "monitor": "val_loss",
+        "min_delta": 0.001,
+        "patience": 8,
+        "start_from_epoch": 20,
+        "mode": "min",
+    },
+})
 
+chatties_baseline = DenseClassifier.derive("chatties_baseline", cls_dict={
+    "training_configs": configs_config["24"],
+    "layers": (128, 64, 32),
+    "learningrate": 1e-3,
+    "batchsize": 4096,
+    "dropout": 0.3,
+    "train_nodes": train_nodes_config.mergedbkgs,
+    "epochs": 100,
+    "early_stopping_kwargs": {
+        "monitor": "val_f1_score",
+        "min_delta": 0.001,
+        "patience": 10,
+        "start_from_epoch": 20,
+        "mode": "max",
+    },
+    "reduce_lr_kwargs": {
+        "monitor": "val_loss",
+        "factor": 0.5,
+        "patience": 5,
+        "min_delta": 0.001,
+        "mode": "min",
+    },
+    "steps_per_epoch": 200.0,
+    "callbacks": {
+        "backup", "checkpoint", "reduce_lr",
+        "early_stopping",
+    },
+    "train_val_test_split": (0.6, 0.2, 0.2),
+    "input_features": input_features_config.no_btag_scores,
+    "loss": "focal_loss",
+    "focal_loss_alpha": 1.0,
+    "focal_loss_gamma": 2.0,
+})
+
+tt_st_classifier = DenseClassifier.derive("tt_st_classifier", cls_dict={
+    "training_configs": configs_config["24"],
+    "processes": ["tt", "st"],
+    "input_features": input_features_config.no_btag_scores,
+    "class_factors": class_factors_config.default,
+    "train_nodes": {
+        "tt": {"ml_id": 0},
+        "st": {"ml_id": 1},
+    },
+    "learningrate": 0.0001,
+    "epochs": 100,
+    "batchsize": 2 ** 10,
+    "dropout": 0.3,
+    "reduce_lr_kwargs": {
+        "monitor": "val_loss",
+        "factor": 0.5,
+        "patience": 5,
+        "min_delta": 0.001,
+        "mode": "min",
+    },
+    "early_stopping_kwargs": {
+        "monitor": "val_loss",
+        "min_delta": 0.001,
+        "patience": 8,
+        "start_from_epoch": 20,
+        "mode": "min",
+    },
+    "layers": (512, 512),
+    "train_val_test_split": (0.6, 0.2, 0.2),
+    "steps_per_epoch": 100.0,
+    "callbacks": {
+        "backup", "checkpoint", "reduce_lr",
+        "early_stopping",
+    },
+})
+
+tt_st_highlevel = tt_st_classifier.derive("tt_st_highlevel", cls_dict={
+    "input_features": tuple([
+        "n_jet",
+        "n_fatjet",
+        "n_bjet",
+        "ht_jets",
+        "ht_fatjets",
+        "ht_sum",
+        "st",
+        "leading_jets_deltar",
+        "leading_fatjets_deltar",
+        "leading_jetfatjet_deltar",
+    ]) + tuple([
+        f"jet_{i + 1}_{var}"
+        for var in ("pt", "eta", "mass")
+        for i in range(5)
+    ]) + tuple([
+        f"fatjet_{i + 1}_{var}"
+        for var in ("pt", "eta", "msoftdrop", "tau21", "tau32")
+        for i in range(3)
+    ]) + tuple([
+        f"lepton_{var}"
+        for var in ("pt", "eta",)
+    ]) + tuple([
+        f"met_{var}"
+        for var in ("pt", "phi")
+    ]),
+    "batchsize": 4096,
+})
+
+v5_red_stats = v5.derive("v5_red_stats", cls_dict={
+    # "steps_per_epoch": 10.0,
+    "batchsize": 4096,
+})
+
+v5_balanced = v5.derive("v5_balanced", cls_dict={
+    "class_factors": class_factors_config.naive_balanced,
+    "input_features": (
+        input_features_config.ak4_jets_all
+        + input_features_config.ak8_fatjets_all
+        + input_features_config.lepton_all
+        + input_features_config.met_all
+        + input_features_config.jet_multiplicity
+    ),
+})
+
+v5_more_balanced = v5.derive("v5_more_balanced", cls_dict={
+    "class_factors": class_factors_config.more_balanced,
+    "input_features": (
+        input_features_config.ak4_jets_all
+        + input_features_config.ak8_fatjets_all
+        + input_features_config.lepton_all
+        + input_features_config.met_all
+        + input_features_config.jet_multiplicity
+    ),
+})
+
+# first optuna run results 11.03.26
+# {
+# 'n_layers': 2,
+# 'units_l0': 1024, 'dropout_l0': 0.15000000000000002,
+# 'units_l1': 128, 'dropout_l1': 0.05,
+# 'learning_rate': 0.002725378204287723, 'batch_size': 512, 'epochs': 90,
+# 'early_stopping_patience': 9,
+# 'learning_rate_reduction_factor': 0.1, 'learning_rate_reduction_patience': 3
+# }
+
+v6_optuna = DenseClassifier.derive("v6_optuna", cls_dict={
+    "class_factors": class_factors_config.default,
+    "input_features": (
+        input_features_config.ak4_jets_all
+        + input_features_config.btag_scores
+        + input_features_config.ak8_fatjets_all
+        + input_features_config.lepton_all
+        + input_features_config.met_all
+        + input_features_config.jet_multiplicity
+    ),
+    "layers": (1024, 128),
+    "dropout": 0.15,
+    "learningrate": 0.002725378204287723,
+    "batchsize": 512,
+    "epochs": 90,
+    "early_stopping_kwargs": {
+        "monitor": "val_loss",
+        "min_delta": 0.001,
+        "patience": 9,
+        "start_from_epoch": 20,
+        "mode": "min",
+    },
+    "reduce_lr_kwargs": {
+        "monitor": "val_loss",
+        "factor": 0.1,
+        "patience": 3,
+        "min_delta": 0.001,
+        "mode": "min",
+    },
+    "steps_per_epoch": 50.0,
+    "train_val_test_split": (0.6, 0.2, 0.2),
+})
+
+v7 = v2_AN_v12.derive("v7", cls_dict={
+    "steps_per_epoch": 50.0,
+    "batchsize": 4096,
+    "input_features": (
+        input_features_config.ak4_jets_all
+        + input_features_config.btag_scores
+        + input_features_config.ak8_fatjets_all
+        + input_features_config.lepton_all
+        + input_features_config.met_all
+        + input_features_config.jet_multiplicity
+    ),
+    "folds": 3,
+})
+
+v8 = DenseClassifier.derive("v8", cls_dict={
+    "steps_per_epoch": 50.0,
+    "batchsize": 4096,
+    "input_features": (
+        input_features_config.ak4_jets_all
+        + input_features_config.btag_scores
+        + input_features_config.ak8_fatjets_all
+        + input_features_config.lepton_all
+        + input_features_config.met_all
+        + input_features_config.jet_multiplicity
+    ),
+    "folds": 5,
+    "class_factors": {
+        "tt": 1,
+        "dy": 1,
+        "w_lnu": 1,
+    },
+    "train_nodes": {
+        "tt": {"ml_id": 0},
+        "other": {
+            "ml_id": 1,
+            "sub_processes": ["dy", "w_lnu"],
+            "label": "Other",
+            "color": "#5E8FFC",  # blue
+            "class_factor_mode": "xsec",
+        },
+    },
+    "train_val_test_split": (0.6, 0.2, 0.2),
+    "processes": [
+        "tt",
+        "dy",
+        "w_lnu",
+    ],
+})
 
 
 

--- a/mtt/ml/mixins.py
+++ b/mtt/ml/mixins.py
@@ -58,7 +58,7 @@ class DenseModelMixin(object):
         self.learningrate = float(self.learningrate)
 
         self.loss = str(self.loss)
-        self.focal_loss_alpha = float(self.focal_loss_alpha)
+        self.focal_loss_alpha = float(self.focal_loss_alpha) if self.focal_loss_alpha is not None else None
         self.focal_loss_gamma = float(self.focal_loss_gamma)
 
     def prepare_ml_model(
@@ -521,6 +521,7 @@ class ModelFitMixin(CallbacksBase):
             logger.debug(f"Using steps per epoch: {steps_per_epoch}")
 
         else:
+            logger.info(f"Using fixed steps_per_epoch: {self.steps_per_epoch}")
             steps_per_epoch = self.steps_per_epoch
 
         logger.info(f"Training will be done with {steps_per_epoch} steps per epoch")

--- a/mtt/production/features.py
+++ b/mtt/production/features.py
@@ -120,7 +120,7 @@ def jet_lepton_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         attach_coffea_behavior,
         jj_features,
         jet_lepton_features,
-        "Electron.pt", "Muon.pt", "FatJet.pt", "Jet.pt",
+        "Electron.pt", "Muon.pt", "FatJet.pt", "Jet.pt", "BJet.pt", "LightJet.pt",
     },
     produces={
         attach_coffea_behavior,
@@ -129,6 +129,8 @@ def jet_lepton_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         "ht",
         "n_jet",
         "n_fatjet",
+        "n_bjet",
+        "n_lightjet",
         "n_muon",
         "n_electron",
     },
@@ -144,12 +146,16 @@ def features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     # before evaluating `ak.num`
     jet = ak.without_parameters(events.Jet)
     fatjet = ak.without_parameters(events.FatJet)
+    bjet = ak.without_parameters(events.BJet)
+    lightjet = ak.without_parameters(events.LightJet)
     muon = ak.without_parameters(events.Muon)
     electron = ak.without_parameters(events.Electron)
 
     # count objects using `pt` fields as a proxy
     events = set_ak_column(events, "n_jet", ak.num(jet.pt, axis=-1))
     events = set_ak_column(events, "n_fatjet", ak.num(fatjet.pt, axis=-1))
+    events = set_ak_column(events, "n_bjet", ak.num(bjet.pt, axis=-1))
+    events = set_ak_column(events, "n_lightjet", ak.num(lightjet.pt, axis=-1))
     events = set_ak_column(events, "n_muon", ak.num(muon.pt, axis=-1))
     events = set_ak_column(events, "n_electron", ak.num(electron.pt, axis=-1))
 

--- a/mtt/production/ml_inputs.py
+++ b/mtt/production/ml_inputs.py
@@ -14,6 +14,7 @@ from mtt.config.variables import add_variables_ml
 from mtt.config.categories import add_categories_production
 from mtt.production.weights import weights
 from mtt.production.lepton import choose_lepton
+from mtt.production.ttbar_reco import ttbar
 
 ak = maybe_import("awkward")
 np = maybe_import("numpy")
@@ -30,13 +31,11 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
         choose_lepton,
         # AK4 jets
         "Jet.pt", "Jet.eta", "Jet.phi", "Jet.mass",
-        "Jet.btagUParTAK4B",
         # AK8 jets
         "FatJet.pt", "FatJet.eta", "FatJet.phi", "FatJet.mass",
         "FatJet.msoftdrop",
         "FatJet.tau1", "FatJet.tau2", "FatJet.tau3",
-        # MET
-        "PuppiMET.pt", "PuppiMET.phi",
+        "BJet.pt",
     },
     produces={
         weights,
@@ -44,6 +43,10 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
     },
 )
 def ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    # set several columns different for eras
+    met_col = self.config_inst.x.met_selection.column
+    btag_col = self.config_inst.x.jet_selection.ak4.btagger.column
+
     # attach coffea behavior
     events = ak.Array(events, behavior=coffea.nanoevents.methods.nanoaod.behavior)
 
@@ -52,23 +55,101 @@ def ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
     # run dependencies
     events = self[choose_lepton](events, **kwargs)
+    # events = self[ttbar](events, **kwargs)
 
     # object arrays
     jet = ak.with_name(events.Jet, "Jet")
     fatjet = ak.with_name(events.FatJet, "FatJet")
     lepton = ak.with_name(events.Lepton, "PtEtaPhiMLorentzVector")
-    met = events.PuppiMET
+    met = events[met_col]
 
     # btag score for AK4 jets
-    jet["btagUParTAK4B"] = jet.btagUParTAK4B  # FIXME make configurable from config
+    # get btagging working points for the given column from config
+    wp_dict = self.config_inst.x.btag_wp[btag_col]
+    edges = sorted(wp_dict.values())
 
-    # n-subjettiness discriminants for AK8 jets
-    fatjet["tau32"] = fatjet.tau3 / fatjet["tau2"]  # avoid fatjet.tau2 to prevent conflict with vector behaviour
-    fatjet["tau21"] = fatjet["tau2"] / fatjet.tau1
+    scores = jet[btag_col]
+
+    # count how many WPs are passed
+    buckets = sum(scores >= edge for edge in edges)
+
+    jet = ak.with_field(jet, buckets, f"{btag_col}_buckets")
+
+    # store btag pass/fail decision as boolean for each WP as well
+    # 1: pass, 0: fail, -1: undefined (e.g. no jet or no score)
+    for wp, edge in wp_dict.items():
+        pass_fail = ak.where(scores >= edge, 1, 0)
+        pass_fail = ak.where(ak.is_none(scores), -1, pass_fail)
+        jet = ak.with_field(jet, pass_fail, f"{btag_col}_pass_{wp}")
+
+    # n-subjettiness discriminants for AK8 jets with safe division
+    # avoid fatjet.tau2 to prevent conflict with vector behaviour
+    fatjet["tau32"] = ak.where(
+        (fatjet["tau2"] != 0) & (fatjet.tau3 != 0),
+        fatjet.tau3 / fatjet["tau2"],
+        -1,
+    )
+
+    fatjet["tau21"] = ak.where(
+        (fatjet.tau1 != 0) & (fatjet.tau2 != 0),
+        fatjet["tau2"] / fatjet.tau1,
+        -1,
+    )
 
     # jet/fatjet multiplicities
     events = set_ak_column(events, f"{ns}.n_jet", ak.num(events.Jet, axis=1))
     events = set_ak_column(events, f"{ns}.n_fatjet", ak.num(events.FatJet, axis=1))
+    events = set_ak_column(events, f"{ns}.n_bjet", ak.num(events.BJet, axis=1))
+
+    # event-level variables
+    ht_jets = ak.sum(jet.pt, axis=-1)
+    ht_fatjets = ak.sum(fatjet.pt, axis=-1)
+    ht_bjets = ak.sum(events.BJet.pt, axis=-1)
+
+    had_sum = ak.sum(jet.pt, axis=-1) + ak.sum(fatjet.pt, axis=-1)  # don't add bjets to avoid double counting
+
+    st = ak.sum(jet.pt, axis=-1) + lepton.pt + met.pt
+
+    # build deltaR between lepton and jets/fatjets for later use in ML input selection
+    lepton_jet_deltar = ak.firsts(jet.metric_table(lepton), axis=-1)
+    jet = ak.with_field(jet, lepton_jet_deltar, "lepton_deltar")
+    lepton_fatjet_deltar = ak.firsts(fatjet.metric_table(lepton), axis=-1)
+    fatjet = ak.with_field(fatjet, lepton_fatjet_deltar, "lepton_deltar")
+
+    # build deltaR between MET and jets/fatjets for later use in ML input selection
+    # for MET, we can treat it as a particle at phi = met.phi and eta = 0
+    met_vector = ak.zip(
+        {"pt": met.pt, "phi": met.phi, "eta": ak.zeros_like(met.pt)}, with_name="PtEtaPhiMLorentzVector"
+    )
+    met_jet_deltar = ak.firsts(jet.metric_table(met_vector), axis=-1)
+    jet = ak.with_field(jet, met_jet_deltar, "met_deltar")
+    met_fatjet_deltar = ak.firsts(fatjet.metric_table(met_vector), axis=-1)
+    fatjet = ak.with_field(fatjet, met_fatjet_deltar, "met_deltar")
+
+    # build deltaR between two leading jets/fatjets for later use in ML input selection
+    # Safely pad arrays to ensure we have at least 2 elements
+    jet_safe = ak.pad_none(jet, 2)        # Pad to at least 2 jets
+    fatjet_safe = ak.pad_none(fatjet, 2)  # Pad to at least 2 fatjets
+
+    # Now we can safely calculate deltaR (will be None for padded elements)
+    leading_jets_deltar = ak.where(
+        ak.num(jet) >= 2,  # Only use real result if we have 2+ jets
+        jet_safe[:, 0].deltaR(jet_safe[:, 1]),
+        -1.0
+    )
+    leading_fatjets_deltar = ak.where(
+        ak.num(fatjet) >= 2,
+        fatjet_safe[:, 0].deltaR(fatjet_safe[:, 1]),
+        -1.0
+    )
+    leading_jetfatjet_deltar = ak.where(
+        (ak.num(jet) >= 1) & (ak.num(fatjet) >= 1),
+        ak.pad_none(jet, 1)[:, 0].deltaR(ak.pad_none(fatjet, 1)[:, 0]),
+        -1.0
+    )
+
+    # # add reco vars from ttbar reconstruction
+    # TODO find solution without needing to rerun the ttbar producer here
 
     # -- helper functions
 
@@ -79,7 +160,7 @@ def ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         for i, attr in itertools.product(range(1, n_max + 1), attrs):
             value = ak.nan_to_none(getattr(arr[:, i - 1], attr))
             value = ak.fill_none(value, default)
-            events = set_ak_column_f32(events, f"{self.ml_namespace}.{name}_{attr}_{i}", value)
+            events = set_ak_column_f32(events, f"{self.ml_namespace}.{name}_{i}_{attr}", value)
         return events
 
     def set_vars_single(events, name, arr, attrs, default=-10.0):
@@ -89,16 +170,26 @@ def ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
             events = set_ak_column_f32(events, f"{self.ml_namespace}.{name}_{attr}", value)
         return events
 
+    def set_event_vars(events, name, value, default=-10.0):
+        value = ak.nan_to_none(value)
+        value = ak.fill_none(value, default)
+        events = set_ak_column_f32(events, f"{self.ml_namespace}.{name}", value)
+        return events
+
     # AK4 jets
     events = set_vars(
         events, "jet", jet, n_max=5,
-        attrs=("energy", "pt", "eta", "phi", "mass", "btagUParTAK4B"),
+        attrs=("energy", "pt", "eta", "phi", "mass", btag_col, f"{btag_col}_buckets", "lepton_deltar", "met_deltar"),
+    )
+    events = set_vars(
+        events, "jet", jet, n_max=5,
+        attrs=(f"{btag_col}_pass_{wp}" for wp in wp_dict.keys()),
     )
 
     # AK8 jets
     events = set_vars(
         events, "fatjet", fatjet, n_max=3,
-        attrs=("energy", "pt", "eta", "phi", "msoftdrop", "tau21", "tau32", "tau1", "tau2", "tau3"),
+        attrs=("energy", "pt", "eta", "phi", "msoftdrop", "tau21", "tau32", "tau1", "tau2", "tau3", "lepton_deltar", "met_deltar"),
     )
 
     # Lepton
@@ -113,6 +204,16 @@ def ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         attrs=("pt", "phi"),
     )
 
+    # event-level variables
+    events = set_event_vars(events, "ht_jets", ht_jets)
+    events = set_event_vars(events, "ht_fatjets", ht_fatjets)
+    events = set_event_vars(events, "ht_bjets", ht_bjets)
+    events = set_event_vars(events, "ht_sum", had_sum)
+    events = set_event_vars(events, "st", st)
+    events = set_event_vars(events, "leading_jets_deltar", leading_jets_deltar)
+    events = set_event_vars(events, "leading_fatjets_deltar", leading_fatjets_deltar)
+    events = set_event_vars(events, "leading_jetfatjet_deltar", leading_jetfatjet_deltar)
+
     # weights
     events = self[weights](events, **kwargs)
 
@@ -123,18 +224,25 @@ def ml_inputs(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 def ml_inputs_init(self: Producer) -> None:
     # put ML input columns in separate namespace/table
     self.ml_namespace = "MLInput"
+    btag_col = self.config_inst.x.jet_selection.ak4.btagger.column
+    met_col = self.config_inst.x.met_selection.column
 
     # store column names
     self.ml_columns = {
         "n_jet",
         "n_fatjet",
+        "n_bjet",
     } | {
-        f"jet_{var}_{i + 1}"
-        for var in ("energy", "pt", "eta", "phi", "mass", "btagUParTAK4B")
+        f"jet_{i + 1}_{var}"
+        for var in ("energy", "pt", "eta", "phi", "mass", btag_col, f"{btag_col}_buckets", "lepton_deltar", "met_deltar")
         for i in range(5)
     } | {
-        f"fatjet_{var}_{i + 1}"
-        for var in ("energy", "pt", "eta", "phi", "msoftdrop", "tau21", "tau32", "tau1", "tau2", "tau3")
+        f"jet_{i + 1}_{btag_col}_pass_{wp}"
+        for wp in self.config_inst.x.btag_wp[btag_col].keys()
+        for i in range(5)
+    } | {
+        f"fatjet_{i + 1}_{var}"
+        for var in ("energy", "pt", "eta", "phi", "msoftdrop", "tau21", "tau32", "tau1", "tau2", "tau3", "lepton_deltar", "met_deltar")
         for i in range(3)
     } | {
         f"lepton_{var}"
@@ -142,6 +250,10 @@ def ml_inputs_init(self: Producer) -> None:
     } | {
         f"met_{var}"
         for var in ("pt", "phi")
+    } | {
+        "ht_jets", "ht_fatjets", "ht_bjets", "ht_sum", "st",
+    } | {
+        "leading_jets_deltar", "leading_fatjets_deltar", "leading_jetfatjet_deltar",
     }
 
     # declare produced columns
@@ -159,3 +271,8 @@ def ml_inputs_init(self: Producer) -> None:
     if not self.config_inst.get_aux("has_variables_ml", False):
         add_variables_ml(self.config_inst)
         self.config_inst.x.has_variables_ml = True
+
+    self.uses |= {
+        f"Jet.{btag_col}",
+        f"{met_col}.pt", f"{met_col}.phi",
+    }

--- a/mtt/production/weights.py
+++ b/mtt/production/weights.py
@@ -104,10 +104,12 @@ def weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         events = self[muon_id_iso_weights](events, **kwargs)
 
         # compute btag weights
-        jet_mask = (events.Jet["pt"] >= 100) & (abs(events.Jet["eta"]) < 2.5)
         if self.config_inst.x.year in [2022, 2023]:
+            jet_mask = (events.Jet["pt"] >= 100) & (abs(events.Jet["eta"]) < 2.5)
             events = self[btag_weights](events, jet_mask=jet_mask, **kwargs)
+        # different for 2024 and not for qcd datasets
         elif self.config_inst.x.year == 2024:
+            jet_mask = (events.Jet["pt"] < 10_000) & (abs(events.Jet["eta"]) < 2.5)
             events = self[btag_wp_weights](events, jet_mask=jet_mask, **kwargs)
 
         # FIXME: not all weights are available for run 3

--- a/mtt/production/weights.py
+++ b/mtt/production/weights.py
@@ -6,9 +6,9 @@ Producers related to event weights.
 
 from columnflow.production import Producer, producer
 from columnflow.production.cms.btag import btag_weights, btag_wp_weights
-from columnflow.production.cms.electron import electron_weights
+from columnflow.production.cms.electron import electron_weights, ElectronSFConfig
 from columnflow.production.cms.mc_weight import mc_weight
-from columnflow.production.cms.muon import muon_weights
+from columnflow.production.cms.muon import muon_weights, MuonSFConfig
 from columnflow.production.normalization import normalization_weights
 from columnflow.production.cms.pileup import pu_weight
 from columnflow.util import maybe_import
@@ -21,6 +21,76 @@ from mtt.production.toptag import toptag_weights
 ak = maybe_import("awkward")
 
 
+muon_id_weights = muon_weights.derive(
+    "muon_id_weights",
+    cls_dict={
+        "weight_name": "muon_id_weight",
+        "get_muon_config": (lambda self: MuonSFConfig.new(self.config_inst.x.muon_iso_sf_config)),
+    }
+)
+muon_iso_weights = muon_weights.derive(
+    "muon_iso_weights",
+    cls_dict={
+        "weight_name": "muon_iso_weight",
+        "get_muon_config": (lambda self: MuonSFConfig.new(self.config_inst.x.muon_id_sf_config)),
+    }
+)
+
+electron_reco_weights = electron_weights.derive(
+    "electron_reco_weights",
+    cls_dict={
+        "weight_name": "electron_reco_weight",
+        "get_electron_config": (lambda self: ElectronSFConfig.new(self.config_inst.x.electron_reco_sf_config)),
+    }
+)
+electron_id_iso_weights = electron_weights.derive(
+    "electron_id_iso_weights",
+    cls_dict={
+        "weight_name": "electron_id_iso_weight",
+        "get_electron_config": (lambda self: ElectronSFConfig.new(self.config_inst.x.electron_id_iso_sf_config)),
+    }
+)
+
+
+@producer(
+    uses={muon_id_weights, muon_iso_weights},
+    produces={muon_id_weights, muon_iso_weights},
+    mc_only=True,
+)
+def muon_id_iso_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Producer to compute muon ID and isolation weights separately.
+    """
+    lep_sel = self.config_inst.x.lepton_selection["mu"]
+    muon_mask = (events.Muon["pt"] >= 30) & (abs(events.Muon["eta"]) < 2.4)
+    events = self[muon_id_weights](events, muon_mask=muon_mask, **kwargs)
+    # only apply iso weights to muons in low pt regime
+    muon_mask = muon_mask & (events.Muon["pt"] < lep_sel["min_pt"]["high_pt"])
+    events = self[muon_iso_weights](events, muon_mask=muon_mask, **kwargs)
+    return events
+
+
+@producer(
+    uses={electron_reco_weights, electron_id_iso_weights},
+    produces={electron_reco_weights, electron_id_iso_weights},
+    mc_only=True,
+)
+def electron_reco_id_iso_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Producer to compute electron reconstruction, ID and isolation weights separately.
+    """
+    lep_sel = self.config_inst.x.lepton_selection["e"]
+    if self.config_inst.x.year in [2022, 2023]:
+        electron_mask = (events.Electron["pt"] >= 35)
+    elif self.config_inst.x.year == 2024:
+        electron_mask = ((events.Electron["pt"] >= 20.0) & (events.Electron["pt"] < 1000.0))
+    events = self[electron_reco_weights](events, electron_mask=electron_mask, **kwargs)
+    # only apply iso weights to electrons in low pt regime
+    electron_mask = electron_mask & (events.Electron["pt"] < lep_sel["min_pt"]["high_pt"])
+    events = self[electron_id_iso_weights](events, electron_mask=electron_mask, **kwargs)
+    return events
+
+
 @producer
 def weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
@@ -28,15 +98,10 @@ def weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
     if self.dataset_inst.is_mc:
         # compute electron weights
-        if self.config_inst.x.year in [2022, 2023]:
-            electron_mask = (events.Electron["pt"] >= 35)
-        elif self.config_inst.x.year == 2024:
-            electron_mask = ((events.Electron["pt"] >= 20.0) & (events.Electron["pt"] < 1000.0))
-        events = self[electron_weights](events, electron_mask=electron_mask, **kwargs)
+        events = self[electron_reco_id_iso_weights](events, **kwargs)
 
         # compute muon weights
-        muon_mask = (events.Muon["pt"] >= 30) & (abs(events.Muon["eta"]) < 2.4)
-        events = self[muon_weights](events, muon_mask=muon_mask, **kwargs)
+        events = self[muon_id_iso_weights](events, **kwargs)
 
         # compute btag weights
         jet_mask = (events.Jet["pt"] >= 100) & (abs(events.Jet["eta"]) < 2.5)
@@ -79,7 +144,7 @@ def weights_init(self: Producer) -> None:
     if getattr(self, "dataset_inst", None) and self.dataset_inst.is_mc:
         # dynamically add dependencies if running on MC
         self.uses |= {
-            electron_weights, muon_weights,
+            electron_reco_id_iso_weights, muon_id_iso_weights,
             # btag_weights,
             normalization_weights,
             pu_weight,
@@ -88,7 +153,7 @@ def weights_init(self: Producer) -> None:
             "Muon.{pt,eta,phi}",
         }
         self.produces |= {
-            electron_weights, muon_weights,
+            electron_reco_id_iso_weights, muon_id_iso_weights,
             # btag_weights,
             normalization_weights,
             pu_weight,

--- a/mtt/production/weights.py
+++ b/mtt/production/weights.py
@@ -5,7 +5,7 @@ Producers related to event weights.
 """
 
 from columnflow.production import Producer, producer
-from columnflow.production.cms.btag import btag_weights
+from columnflow.production.cms.btag import btag_weights, btag_wp_weights
 from columnflow.production.cms.electron import electron_weights
 from columnflow.production.cms.mc_weight import mc_weight
 from columnflow.production.cms.muon import muon_weights
@@ -19,18 +19,6 @@ from mtt.production.gen_v import vjets_weight
 from mtt.production.toptag import toptag_weights
 
 ak = maybe_import("awkward")
-
-btag_uncs = {
-    "fsrdef": "fsrdef",
-    "hdamp": "hdamp",
-    "isrdef": "isrdef",
-    "jer": "jer",
-    "jes": "jes",
-    "mass": "mass",
-    "statistic": "statistic",
-    "tune": "tune",
-}
-upart_btag_weights = btag_weights.derive("upart_btag_weights", cls_dict={"btag_uncs": btag_uncs})
 
 
 @producer
@@ -55,7 +43,7 @@ def weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         if self.config_inst.x.year in [2022, 2023]:
             events = self[btag_weights](events, jet_mask=jet_mask, **kwargs)
         elif self.config_inst.x.year == 2024:
-            events = self[upart_btag_weights](events, jet_mask=jet_mask, **kwargs)
+            events = self[btag_wp_weights](events, jet_mask=jet_mask, **kwargs)
 
         # FIXME: not all weights are available for run 3
         if self.config_inst.x.run == 2:
@@ -127,8 +115,8 @@ def weights_init(self: Producer) -> None:
             }
         elif self.config_inst.x.year == 2024:
             self.uses |= {
-                upart_btag_weights,
+                btag_wp_weights,
             }
             self.produces |= {
-                upart_btag_weights,
+                btag_wp_weights,
             }

--- a/mtt/selection/categories.py
+++ b/mtt/selection/categories.py
@@ -48,3 +48,38 @@ def sel_1t(self: Categorizer, events: ak.Array, **kwargs) -> ak.Array:
     """Select only events with exactly one top-tagged fat jet."""
     mask = (Route("cutflow.n_toptag_delta_r_lepton").apply(events) == 1)
     return events, mask
+
+
+@categorizer(uses={"cutflow.n_jet"})
+def sel_0j(self: Categorizer, events: ak.Array, **kwargs) -> ak.Array:
+    """Select only events with zero jets."""
+    mask = (Route("cutflow.n_jet").apply(events) == 0)
+    return events, mask
+
+
+@categorizer(uses={"cutflow.n_jet"})
+def sel_1j(self: Categorizer, events: ak.Array, **kwargs) -> ak.Array:
+    """Select only events with exactly one jet."""
+    mask = (Route("cutflow.n_jet").apply(events) == 1)
+    return events, mask
+
+
+@categorizer(uses={"cutflow.n_jet"})
+def sel_2j(self: Categorizer, events: ak.Array, **kwargs) -> ak.Array:
+    """Select only events with exactly two jets."""
+    mask = (Route("cutflow.n_jet").apply(events) == 2)
+    return events, mask
+
+
+@categorizer(uses={"cutflow.n_jet"})
+def sel_3j(self: Categorizer, events: ak.Array, **kwargs) -> ak.Array:
+    """Select only events with three or more jets."""
+    mask = (Route("cutflow.n_jet").apply(events) >= 3)
+    return events, mask
+
+
+@categorizer(uses={"Jet.pt"})
+def sel_3j_alt(self: Categorizer, events: ak.Array, **kwargs) -> ak.Array:
+    """Select only events with three or more jets."""
+    mask = ak.num(events.Jet.pt, axis=1) >= 3
+    return events, mask

--- a/mtt/selection/default.py
+++ b/mtt/selection/default.py
@@ -8,7 +8,7 @@ from operator import and_
 from functools import reduce
 from collections import defaultdict
 
-from columnflow.util import maybe_import
+from columnflow.util import maybe_import, DotDict
 from columnflow.production.util import attach_coffea_behavior
 
 from columnflow.selection import Selector, SelectionResult, selector
@@ -16,6 +16,7 @@ from columnflow.selection.stats import increment_stats
 from columnflow.selection.cms.met_filters import met_filters
 from columnflow.selection.cms.json_filter import json_filter
 from columnflow.selection.cms.jets import jet_veto_map
+from columnflow.selection.cms.btag import fill_btag_wp_count_hists
 from columnflow.production.categories import category_ids
 from columnflow.production.cms.mc_weight import mc_weight
 from columnflow.production.processes import process_ids
@@ -35,6 +36,7 @@ from mtt.util import print_log_msg
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
+hist = maybe_import("hist")
 
 
 @selector(
@@ -75,6 +77,7 @@ def default(
     self: Selector,
     events: ak.Array,
     stats: defaultdict,
+    hists: DotDict[str, hist.Hist],
     **kwargs,
 ) -> tuple[ak.Array, SelectionResult]:
     # ensure coffea behavior
@@ -138,6 +141,12 @@ def default(
 
     n_sel = ak.sum(event_sel, axis=-1)
     print_log_msg(f"__all__: {n_sel}", print_msg=True)
+
+    # fill btagging efficiency histograms (in-place, so no return value)
+    # ! note that this uses selected jets only of selected events with the full "event_sel", so selecting a subset
+    # of selection-steps later on will not affect these histograms
+    if self.dataset_inst.is_mc and self.has_dep(fill_btag_wp_count_hists):
+        self[fill_btag_wp_count_hists](events, results.event, results.objects.Jet.Jet, hists, **kwargs)
 
     # # produce features relevant for selection and event weights
     # if self.dataset_inst.has_tag("is_sm_ttbar"):
@@ -224,3 +233,11 @@ def default_init(self: Selector) -> None:
     if hasattr(self, "dataset_inst") and not self.dataset_inst.is_mc:
         self.uses |= {data_trigger_veto}
         self.produces |= {data_trigger_veto}
+
+    if hasattr(self, "dataset_inst") and self.dataset_inst.is_mc:
+        self.uses |= {
+            fill_btag_wp_count_hists,
+        }
+        self.produces |= {
+            fill_btag_wp_count_hists,
+        }

--- a/workflow_scripts/dnn_workflow.sh
+++ b/workflow_scripts/dnn_workflow.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-ML_MODEL=v1_AN_v12
+ML_MODEL=v7
 
 # common args
 common_args=(
 
-    --version 251209_v5
+    --version 260219_v7
     --config run3_mtt_2024_nano_v15_new
     --analysis mtt.config.run3.analysis_mtt.analysis_mtt_new
     --local-scheduler False
-    --cf.BundleRepo-custom-checksum v_0113_1125
-    --workers 10
+    --cf.BundleRepo-custom-checksum v_0326_1400
+    --workers 50
     --cf.CalibrateEvents-htcondor-memory 7GB
     --cf.SelectEvents-htcondor-memory 7GB
     $@
@@ -18,60 +18,118 @@ common_args=(
 
 # reduce events
 # loop over datasets to avoid having too many htcondor jobs at once (capped at 5000 jobs)
-for ds in tt st dy w_lnu qcd vv; do
+for ds in tt st dy w_lnu qcd vv data zprime_tt_m500_w5_madgraph zprime_tt_m4000_w40_madgraph zprime_tt_m4500_w45_madgraph zprime_tt_m7000_w70_madgraph; do
     echo "Reducing $ds"
     echo claw run cf.ReduceEventsWrapper \
     --cf.ReduceEvents-workflow htcondor \
-    --cf.ReduceEvents-pilot \
     --cf.ReduceEvents-htcondor-memory 4GB \
+    --cf.ReduceEvents-pilot \
     --datasets $ds \
+    --cf.CalibrateEvents-version 260216_v6 \
     "${common_args[@]}"
 done
 
 # produce columns
-for prod in ttbar features weights ml_inputs; do
-    echo claw run cf.ProduceColumnsWrapper \
-        --datasets all \
-        --cf.ProduceColumns-producer $prod \
-        --cf.ProduceColumns-workflow htcondor \
-        --cf.ProduceColumns-selector default \
-        --cf.ProduceColumns-pilot \
-        --cf.ProduceColumns-htcondor-memory 5GB \
-        --cf.MergeReducedEvents-workflow local \
-        --cf.MergeSelectionStats-workflow local \
-        --remove-output 0,a,y \
-        "${common_args[@]}"
+for prod in ml_inputs; do
+    # for ds in tt_fh_powheg; do
+    for ds in bkg; do
+        echo "Producing columns with $prod for dataset $ds"
+        echo law run cf.ProduceColumnsWrapper \
+            --datasets $ds \
+            --cf.ProduceColumns-producer $prod \
+            --cf.ProduceColumns-selector default \
+            --cf.ProduceColumns-workflow htcondor \
+            --cf.ProduceColumns-pilot \
+            --cf.ProduceColumns-htcondor-memory 2GB \
+            --cf.CalibrateEvents-version 260216_v6 \
+            --cf.MergeSelectionStats-workflow local \
+            --remove-output 0,a,y \
+            "${common_args[@]}"
+    done
 done
+
+echo law run cf.PlotVariables1D \
+    --selector default \
+    --variables AN_v12_mli_jet_btagUParTAK4B_1,AN_v12_mli_jet_btagUParTAK4B_2,AN_v12_mli_jet_btagUParTAK4B_3 \
+    --producers add_prod_cats,ttbar,features,weights,ml_inputs \
+    --hist-producer all_weights \
+    --processes tt,w_lnu,st,dy,vv,qcd \
+    --process-settings tt,unstack:w_lnu,unstack:st,unstack:dy,unstack:vv,unstack:qcd,unstack \
+    --yscale log \
+    --categories 1m,1e \
+    --cms-label simpw \
+    --file-types pdf,png \
+    --workflow local \
+    "${common_args[@]}"
+
+# plot input variable distributions
+echo law run cf.PlotVariables1D \
+    --variables "gen_ttbar_mass_narrow_ext" \
+    --selector default \
+    --producers add_prod_cats,ttbar,features,weights \
+    --hist-producer all_weights \
+    --processes zprime_tt_m500_w5,zprime_tt_m4000_w40,zprime_tt_m7000_w70 \
+    --process-settings tt,unstack:zprime_tt_m7000_w70,unstack:zprime_tt_m500_w5,unstack:zprime_tt_m4000_w40,unstack:zprime_tt_m7000_w70,unstack \
+    --categories incl \
+    --cms-label simpw \
+    --file-types pdf,png \
+    --workflow local \
+    --shape-norm \
+    --yscale log \
+    --skip-ratio \
+    --remove-output 0,a,y \
+    "${common_args[@]}"
 
 # ML training and plotting
 echo law run cf.MLTraining \
     --ml-model $ML_MODEL \
-    --workflow htcondor \
     --cf.MLTraining-htcondor-memory 30GB \
     --cf.MLTraining-htcondor-runtime 4h \
-    --mtt.MLPreTraining-htcondor-memory 10GB \
+    --mtt.MLPreTraining-htcondor-memory 35GB \
+    --mtt.MLPreTraining-workflow htcondor \
+    --workflow htcondor \
     "${common_args[@]}"
 
-echo law run mtt.PlotMLResultsSingleFold \
+law run mtt.PlotMLResultsSingleFold \
     --ml-model $ML_MODEL \
-    --fold 0 \
     --workflow htcondor \
     --mtt.PlotMLResultsSingleFold-htcondor-memory 20GB \
+    --mtt.MLPreTraining-htcondor-memory 30GB \
+    --mtt.MLPreTraining-workflow htcondor \
     "${common_args[@]}"
 
 # final plots of output node distributions and ttbar mass
-law run cf.PlotVariables1D \
+echo law run cf.PlotVariables1D \
+    --cf.MLTraining-htcondor-memory 30GB \
+    --cf.MLTraining-htcondor-runtime 4h \
+    --mtt.MLPreTraining-htcondor-memory 15GB \
+    --mtt.MLPreTraining-workflow local \
+    --cf.MLEvaluation-version 251209_v5 \
     --selector default \
     --producers add_prod_cats,ttbar,features,weights,ml_inputs,add_ml_cats_$ML_MODEL \
     --ml-models $ML_MODEL \
     --hist-producer all_weights \
     --variables ttbar_mass_ext,mlscore.tt,mlscore.st,mlscore.other \
-    --categories incl,1m__dnn_st,1e__dnn_st,1m__dnn_other,1e__dnn_other \
-    --processes qcd,st,dy,w_lnu,tt \
+    --categories v12_simplified \
+    --processes qcd,st,dy,w_lnu,tt,zprime_tt_m7000_w70,zprime_tt_m500_w5,zprime_tt_m4000_w40 \
     --yscale log \
     --skip-ratio \
     --plot-suffix log \
-    --workflow htcondor \
+    --workflow local \
     --file-types pdf,png \
     --cms-label simpw \
+    --print-status 3 \
     "${common_args[@]}"
+
+# create datacards
+for inf_model in an_v12_simplified__m500_w5 an_v12_simplified__m4000_w40 an_v12_simplified__m4500_w45 an_v12_simplified__m7000_w70; do
+# for inf_model in an_v12_simplified__m7000_w70; do
+    echo "Creating datacard for model $inf_model"
+    echo claw run cf.CreateDatacards \
+        --inference-model $inf_model \
+        --hist-producer all_weights \
+        --selector default \
+        --producers add_prod_cats,ttbar,features,weights,ml_inputs,add_ml_cats_$ML_MODEL \
+        --workflow htcondor \
+        "${common_args[@]}"
+done

--- a/workflow_scripts/plot_limits.py
+++ b/workflow_scripts/plot_limits.py
@@ -19,6 +19,10 @@ logger = law.logger.get_logger(__name__)
 PATH_TO_RUN2_LIMITS = "/data/dust/user/matthiej/run2_datacards/limits/limits_{model}.csv"
 PATH_TO_RUN3_LIMITS = "/data/dust/user/matthiej/mttbar/workflow_scripts/limits/run3_{model}_limits.csv"
 
+PATH_TO_RUN3_OUTPUTS = "/data/dust/user/matthiej/mttbar_fits/outputs/{version}/{ml_model}/{inf_model}__m{mass}_w{width}/zzz_logs/asymptotic_limits_{fit_version}.log"
+# /data/dust/user/matthiej/mttbar_fits/outputs/251209_v5/v3_AN_v12/an_v12_simplified__m7000_w70/zzz_logs/asymptotic_limits_baseline.log
+# /data/dust/user/matthiej/mttbar_fits/outputs/251209_v5/v3_AN_v12/an_v12_simplified__m500_w5/zzz_logs/asymptotic_limits_baseline.log
+
 # Run 2 theory lines
 RUN2_THEORY_LINES = {
     "ZPrime_w1": {
@@ -40,8 +44,313 @@ RUN2_THEORY_LINES = {
 }
 
 
+def extract_limits_from_log(version, ml_model, inf_model, mass, width, fit_version) -> pd.DataFrame:
+    """
+    Extract all expected limits from log file and return as DataFrame.
+    Returns columns: exp_m2s, exp_m1s, exp, exp_p1s, exp_p2s
+    """
+    path = PATH_TO_RUN3_OUTPUTS.format(version=version, ml_model=ml_model, inf_model=inf_model, mass=mass, width=width, fit_version=fit_version)
+    import re
+
+    logger.info(f"Extracting limits from log file: {path}")
+
+    # Dictionary to store all percentiles
+    limits_data = {}
+
+    # Define the expected percentiles and their column names
+    percentiles_map = {
+        "2.5": "exp_m2s",    # -2 sigma (2.5%)
+        "16.0": "exp_m1s",   # -1 sigma (16.0%)  
+        "50.0": "exp",       # median (50.0%)
+        "84.0": "exp_p1s",   # +1 sigma (84.0%)
+        "97.5": "exp_p2s",   # +2 sigma (97.5%)
+    }
+
+    # Regular expression to parse limit lines
+    # Matches: "Expected 50.0%: r < 0.0308"
+    pattern = r"Expected\s+(\d+\.?\d*)%:\s+r\s*<\s*([0-9.e+-]+)"
+
+    with open(path, "r") as f:
+        for line in f:
+            match = re.search(pattern, line)
+            if match:
+                percentage = match.group(1)  # e.g., "50.0"
+                limit_value = float(match.group(2))  # e.g., 0.0308
+
+                # Map to column name
+                if percentage in percentiles_map:
+                    col_name = percentiles_map[percentage]
+                    limits_data[col_name] = limit_value
+                    logger.debug(f"Extracted {percentage}% limit: {limit_value} -> {col_name}")
+
+    # Verify we got all expected values
+    expected_cols = set(percentiles_map.values())
+    found_cols = set(limits_data.keys())
+
+    if not expected_cols.issubset(found_cols):
+        missing = expected_cols - found_cols
+        logger.warning(f"Missing expected limit columns: {missing}")
+
+    # Convert to DataFrame (single row)
+    df = pd.DataFrame([limits_data])
+    logger.debug(f"Extracted limits DataFrame:\n{df}")
+    return df
+
+
+def plot_limits_with_bands(model: str, crosssection: float = 1.0, width: float = 1.0) -> None:
+    green = '#228b22'
+    yellow = '#ffcc00'
+    masses = [
+        500,
+        4000,
+        4500,
+        7000,
+    ]
+    # Extract limits for all masses
+    limits_dfs = []
+    for mass in masses:
+        df = extract_limits_from_log(
+            version="251209_v5",
+            ml_model="v1_AN_v12",
+            inf_model="an_v12_simplified",
+            mass=mass,
+            width=int(mass * width / 100),  # width as percentage of mass
+            fit_version="baseline",
+        )
+        df["m"] = mass  # Add mass
+        limits_dfs.append(df)
+
+    # Concatenate all limits DataFrames
+    all_limits_df = pd.concat(limits_dfs, ignore_index=True)
+    logger.debug(f"All extracted limits:\n{all_limits_df}")
+
+    # set up plot
+    plt.style.use(hep.style.CMS)
+    fig, ax = plt.subplots(figsize=(12, 8))
+    ax.text(
+        200, 170,
+        "Private work (CMS simulation)",
+        fontsize=24,
+        verticalalignment='top',
+        fontproperties="Tex Gyre Heros:italic"
+    )
+    ax.text(
+        6500, 170,
+        r"109 fb$^{-1}$ (13.6 TeV)",
+        fontsize=24,
+        verticalalignment='top',
+        fontproperties="Tex Gyre Heros"
+    )
+
+    # plot Run 3 limits with error bands
+    ax.fill_between(
+        all_limits_df["m"],
+        all_limits_df["exp_m2s"] * crosssection,
+        all_limits_df["exp_p2s"] * crosssection,
+        color=green,
+        label="Run 3 68% Expected",
+        zorder=3,
+    )
+    ax.fill_between(
+        all_limits_df["m"],
+        all_limits_df["exp_m1s"] * crosssection,
+        all_limits_df["exp_p1s"] * crosssection,
+        color=yellow,
+        label="Run 3 95% Expected",
+        zorder=5,
+    )
+    ax.scatter(
+        all_limits_df["m"],
+        all_limits_df["exp"] * crosssection,
+        color='k',
+        marker='o',
+        label="Run 3 Expected",
+        zorder=10,
+    )
+
+    # plot Run 2 theory lines
+    ax.plot(
+        RUN2_THEORY_LINES[model]["X_th"],
+        RUN2_THEORY_LINES[model]["th"],
+        color="gray",
+        linestyle=":",
+        label="Run 2 Theory",
+        zorder=9,
+    )
+
+    run2_limits = load_limits_simple(model, run=2)
+
+    # plot Run 2 limits
+    ax.plot(
+        run2_limits["m"],
+        run2_limits["exp"],
+        label="Run 2 Expected\n(CMS-PAS-B2G-22-006)",
+        color="blue",
+        linestyle="--",
+        zorder=8,
+    )
+
+    # customize plot
+    ax.set_xlabel("Mass [GeV]")
+    ax.set_ylabel("σ × BR (Z' → ttbar) [pb]")
+    ax.set_yscale("log")
+    ax.legend(
+        title='95% CL upper limit',
+        bbox_to_anchor=(0.98, 0.90),  # x=0.98 (right edge), y=0.75 (75% up)
+        loc='upper right'
+    )
+    ax.set_ylim(1e-5, 300)
+
+    # show plot
+    plt.tight_layout()
+    plt.savefig(f"/data/dust/user/matthiej/mttbar/workflow_scripts/limits/{model}__full.png")
+    plt.savefig(f"/data/dust/user/matthiej/mttbar/workflow_scripts/limits/{model}__full.pdf")
+
+
+def plot_limits_simple_with_bands(model: str, crosssection: float = 1.0, width: float = 1.0) -> None:
+    """
+    Plot limits for a given model and assumed signal cross-section, including error bands.
+    """
+    green = '#228b22'
+    yellow = '#ffcc00'
+    masses = [
+        500,
+        4000,
+        4500,
+        7000,
+    ]
+    # Extract limits for all masses
+    limits_dfs = []
+    for mass in masses:
+        df = extract_limits_from_log(
+            version="251209_v5",
+            ml_model="v1_AN_v12",
+            inf_model="an_v12_simplified",
+            mass=mass,
+            width=int(mass * width / 100),  # width as percentage of mass
+            fit_version="baseline",
+        )
+        df["m"] = mass  # Add mass
+        limits_dfs.append(df)
+
+    # Concatenate all limits DataFrames
+    all_limits_df = pd.concat(limits_dfs, ignore_index=True)
+    logger.debug(f"All extracted limits:\n{all_limits_df}")
+    # load limits
+    run2_limits = load_limits_simple(model, run=2)
+    logger.debug(f"Loaded Run 2 limits for model '{model}':\n{run2_limits}")
+
+    # set up plot
+    plt.style.use(hep.style.CMS)
+    fig, ax = plt.subplots(figsize=(12, 8))
+    hep.style.use("CMS")
+    hep.cms.label(
+        'Private Work',
+        data=False,
+        lumi="138/109",
+        ax=ax,
+        com="13/13.6",
+    )
+
+    # plot Run 2 theory lines
+    theory_line, = ax.plot(
+        RUN2_THEORY_LINES[model]["X_th"] / 1000,  # convert to TeV
+        RUN2_THEORY_LINES[model]["th"],
+        color="gray",
+        linestyle=":",
+        zorder=5,
+    )
+    logger.debug(f"Loaded Run 2 limits for model '{model}':\n{run2_limits}")
+
+    # plot Run 2 limits
+    ax.plot(
+        run2_limits["m"] / 1000,  # convert to TeV
+        run2_limits["exp"],
+        label="Run 2 Expected\n(CMS-PAS-B2G-22-006)",
+        color="blue",
+        linestyle="--",
+        zorder=7,
+    )
+    logger.debug(f"Plotted Run 2 limits for model '{model}'")
+
+    # plot Run 3 limits with error bands
+    ax.fill_between(
+        run2_limits["m"] / 1000,  # convert to TeV
+        run2_limits["m2"],
+        run2_limits["p2"],
+        color=green,
+        label="Run 2 68% Expected",
+        zorder=1,
+    )
+    ax.fill_between(
+        run2_limits["m"] / 1000,  # convert to TeV
+        run2_limits["m1"],
+        run2_limits["p1"],
+        color=yellow,
+        label="Run 2 95% Expected",
+        zorder=3,
+    )
+    ax.errorbar(
+        all_limits_df["m"] / 1000,  # convert to TeV
+        all_limits_df["exp"] * crosssection,
+        yerr=[
+            (all_limits_df["exp"] - all_limits_df["exp_m2s"]) * crosssection,
+            (all_limits_df["exp_p2s"] - all_limits_df["exp"]) * crosssection,
+        ],
+        label="Run 3 68% Expected",
+        color='k',
+        marker='o',
+        zorder=10,
+        linestyle='none',
+        markersize=10,
+        elinewidth=3,
+        capsize=6,
+        capthick=2.5,
+        markerfacecolor='black',
+        # markeredgecolor='white',   # white outline
+        markeredgewidth=2.0,       # thick edge
+        ecolor='black',
+    )
+    logger.debug(f"Plotted Run 3 limits with error bars for model '{model}'")
+
+    # customize plot
+    ax.set_xlabel("Mass [TeV]")
+    ax.set_ylabel("σ × BR (Z' → ttbar) [pb]")
+    ax.set_yscale("log")
+    # ax.legend(title='95% CL upper limit')
+    # --- Theory legend ---
+    theory_legend = ax.legend(
+        handles=[theory_line],
+        labels=["Run 2 Theory"],
+        title="Theory prediction",
+        loc="upper center",
+        frameon=False,
+        fontsize=18,
+        title_fontsize=20,
+    )
+
+    ax.add_artist(theory_legend)  # keep it
+
+    # --- Main legend ---
+    ax.legend(
+        title="95% CL upper limit",
+        loc="upper right",
+        frameon=False,
+        fontsize=18,
+        title_fontsize=20,
+    )
+
+    # show plot
+    plt.tight_layout()
+    plt.savefig(f"/data/dust/user/matthiej/mttbar/workflow_scripts/limits/{model}__bands.png")
+    plt.savefig(f"/data/dust/user/matthiej/mttbar/workflow_scripts/limits/{model}__bands.pdf")
+
+    # close plot to free memory
+    plt.close()
+
+
 # load limits from CSV
-def load_limits(model: str, run: int) -> pd.DataFrame:
+def load_limits_simple(model: str, run: int) -> pd.DataFrame:
     """
     Load limits for a given model and Run from CSV file.
     """
@@ -58,13 +367,13 @@ def load_limits(model: str, run: int) -> pd.DataFrame:
     return df
 
 
-def plot_limits(model: str, crosssection: float = 1.0) -> None:
+def plot_limits_simple(model: str, crosssection: float = 1.0) -> None:
     """
     Plot limits for a given model and assumed signal cross-section.
     """
     # load limits
-    run2_limits = load_limits(model, run=2)
-    run3_limits = load_limits(model, run=3)
+    run2_limits = load_limits_simple(model, run=2)
+    run3_limits = load_limits_simple(model, run=3)
 
     # set up plot
     plt.style.use(hep.style.CMS)
@@ -118,4 +427,6 @@ def plot_limits(model: str, crosssection: float = 1.0) -> None:
 
 
 if __name__ == "__main__":
-    plot_limits("ZPrime_w1", crosssection=0.1)
+    # plot_limits_simple("ZPrime_w1", crosssection=0.1)
+    # plot_limits_with_bands("ZPrime_w1", crosssection=0.1, width=1.0)
+    plot_limits_simple_with_bands("ZPrime_w1", crosssection=0.1, width=1.0)

--- a/workflow_scripts/test_workflow.sh
+++ b/workflow_scripts/test_workflow.sh
@@ -3,9 +3,9 @@
 # set parameters
 # datasets=(tt_sl_powheg st_tchannel_t_4f_powheg dy_m4to50_ht800to1500_madgraph ww_pythia w_lnu_mlnu0to120_ht800to1500_madgraph qcd_ht1000to1200_madgraph data_mu_c)
 datasets=(tt_sl_powheg)
-datasets_mc=(tt_sl_powheg st_tchannel_t_4f_powheg dy_m4to50_ht800to1500_madgraph ww_pythia w_lnu_mlnu0to120_ht800to1500_madgraph qcd_ht1000to1200_madgraph)
+# datasets_mc=(tt_sl_powheg st_tchannel_t_4f_powheg dy_m4to50_ht800to1500_madgraph ww_pythia w_lnu_mlnu0to120_ht800to1500_madgraph qcd_ht1000to1200_madgraph)
 
-version=test_updates_251013_v2
+version=test_260619_v9
 analysis=mtt.config.run3.analysis_mtt.analysis_mtt_new
 config=run3_mtt_2024_nano_v15_limited_new
 calibrator=skip_jecunc
@@ -26,14 +26,16 @@ for dataset in "${datasets[@]}"; do
     --dataset $dataset \
     --workflow local \
     --calibrator $calibrator \
-    --remove-output 0,a,y
-    law run cf.SelectEvents \
+    --branch 0
+    echo law run cf.SelectEvents \
     --version $version \
     --analysis $analysis \
     --config $config \
     --dataset $dataset \
     --calibrators $calibrator \
-    --selector $selector
+    --selector $selector \
+    --branch 0 \
+    --remove-output 0,a,y
     echo law run cf.ReduceEvents \
     --version $version \
     --analysis $analysis \
@@ -41,7 +43,8 @@ for dataset in "${datasets[@]}"; do
     --dataset $dataset \
     --calibrators $calibrator \
     --selector $selector \
-    --reducer $reducer
+    --reducer $reducer \
+    --remove-output 0,a,y
     echo law run cf.ProduceColumns \
     --version $version \
     --analysis $analysis \
@@ -50,7 +53,8 @@ for dataset in "${datasets[@]}"; do
     --calibrators $calibrator \
     --producer ttbar \
     --selector $selector \
-    --reducer $reducer
+    --reducer $reducer \
+    --branch 0
     echo law run cf.ProduceColumns \
     --version $version \
     --analysis $analysis \
@@ -59,7 +63,8 @@ for dataset in "${datasets[@]}"; do
     --calibrators $calibrator \
     --producer features \
     --selector $selector \
-    --reducer $reducer
+    --reducer $reducer \
+    --branch 0
     # don't run weights for data
     if [[ $dataset == data* ]]; then
         continue
@@ -114,24 +119,27 @@ echo law run cf.CreateYieldTable \
 #     --datasets $datasets_str \
 
 # plot pt of muon and electron in 1e and 1m - normalized
-echo law run cf.PlotVariables1D \
+law run cf.PlotVariables1D \
     --version $version \
     --analysis $analysis \
     --config $config \
     --producers add_prod_cats,features,weights \
     --datasets $datasets_str \
-    --categories 1m__0t,1e \
-    --variables electron_pt,muon_pt \
+    --processes tt \
+    --categories 1m__2j \
+    --variables electron_pt,muon_pt,n_jet \
     --file-types pdf,png \
     --yscale log \
-    --remove-output 0,a,y \
     --shape-norm \
     --plot-suffix norm \
-    --workers 1 \
+    --workers 5 \
     --workflow local \
     --local-scheduler false \
     --selector $selector \
-    --reducer $reducer
+    --reducer $reducer \
+    --cf.ReduceEvents-version 260619_v8 \
+    --cf.SelectEvents-version 260619_v8 \
+    --cf.CalibrateEvents-version 260619_v8
 
 # plot pt of muon and electron in 1e and 1m - not normalized
 # law run cf.PlotVariables1D \


### PR DESCRIPTION
This PR implements the new (and hopefully correct) b tagging SF calculation introduced by columnflow's [PR #775](https://github.com/columnflow/columnflow/pull/775) and [PR #777](https://github.com/columnflow/columnflow/pull/777) into the analysis to be applied on 2024 MC datasets.

Currently, the BTV POG provides different correction sets for b, c, and light jets, all in a single file, compare [here](https://cms-analysis-corrections.docs.cern.ch/corrections_era/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/BTV/2026-01-30/#btagging_preliminaryjsongz). This makes the weight calculation rather involved, and makes it necessary to first merge the correction sets. This can be done using the script provided ([`merge_btv_corrections.py`](https://github.com/uhh-cms/mttbar/blob/fix/btag_sf/merge_btv_corrections.py)). This then serves as input to the `btag_wp_weights` producer, when configured correctly (using `BTagWPCountConfig` and `BTagWPSFConfig` objects stored in the respective aux variables of the config). 

Since the weights depend on the working point as they require the b tagging efficiencies, they are highly phase space dependent. In the case of low statistics in a given `[process, pT, eta, flavor]` bin, the calculation will give errors , and the binning needs to be adapted. The BTV POG provides binning recommendations [here](https://btv-wiki.docs.cern.ch/PerformanceCalibration/fixedWPSFRecommendations/#b-tagging-efficiencies-in-simulation) (towards the bottom of the page). They need to be adapted for this analysis, making this PR only a draft PR for now.

In addition to the b tagging SF implementation, this PR also includes the reapplication of JEC/R to subjets as well as the recalculation of m_SD for fatjets.

Also, since we only require an isolation criterion in the low pT phase space of our leptons, we also only need to apply the corresponding SF there. This should be done now by making use of the functionality of the `MuonSFConfig` and `ElectronSFConfig` by giving additional pT requirements. This will however be confirmed after the next rerun.